### PR TITLE
Update maven plugin to actually launch the IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - downloads, configures, and launches an instance of the Eclipse IDE
 - ensures that all of your devs have a zero-effort and perfectly repeatable IDE setup process
 
-Use it like this in Gradle:
+Use it like this in Gradle with `gradlew equoIde`:
 
 ```gradle
 plugins {
@@ -20,7 +20,14 @@ equoIde { // launch with gradlew equoIde
 or like this in Maven:
 
 ```xml
-<plugin><!-- launch with mvn equo:ide -->
+<settings> <!-- put this in ~/.m2/settings.xml and launch with mvn equo-ide:equoIde -->
+  <pluginGroups>
+     <pluginGroup>dev.equo.ide</pluginGroup>
+  </pluginGroups>
+  ...
+    
+    
+<plugin><!-- or add this to pom.xml/<project><build><pluginManagement><plugins> to add non-default settings -->
   <groupId>dev.equo.ide</groupId>
   <artifactId>equo-ide-maven-plugin</artifactId>
   <version>${equo.ide.version}</version>

--- a/README.md
+++ b/README.md
@@ -17,17 +17,16 @@ equoIde { // launch with gradlew equoIde
 }
 ```
 
-or like this in Maven:
+or like this in Maven with `mvn equo-ide:launch`:
 
 ```xml
-<settings> <!-- put this in ~/.m2/settings.xml and launch with mvn equo-ide:equoIde -->
+<settings> <!-- put this in ~/.m2/settings.xml -->
   <pluginGroups>
      <pluginGroup>dev.equo.ide</pluginGroup>
   </pluginGroups>
   ...
-    
-    
-<plugin><!-- or add this to pom.xml/<project><build><pluginManagement><plugins> to add non-default settings -->
+
+<plugin><!-- or add this to pom.xml/<project><build><pluginManagement><plugins> -->
   <groupId>dev.equo.ide</groupId>
   <artifactId>equo-ide-maven-plugin</artifactId>
   <version>${equo.ide.version}</version>

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/DepsResolve.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/DepsResolve.java
@@ -17,8 +17,6 @@ import dev.equo.solstice.NestedBundles;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.JarURLConnection;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -27,16 +25,7 @@ import org.gradle.plugin.devel.tasks.PluginUnderTestMetadata;
 
 class DepsResolve {
 	static List<Object> resolveFiles() throws IOException {
-		var solsticeJar =
-				NestedBundles.class.getResource(NestedBundles.class.getSimpleName() + ".class").toString();
-		if (!solsticeJar.startsWith("jar")) {
-			throw new IllegalArgumentException("");
-		}
-		var url = new URL(solsticeJar);
-		var jarConnection = (JarURLConnection) url.openConnection();
-		var manifest = jarConnection.getManifest();
-		var implVersion = manifest.getMainAttributes().getValue("Implementation-Version");
-
+		var implVersion = NestedBundles.solsticeVersion();
 		if (!implVersion.endsWith("-SNAPSHOT")) {
 			return Collections.singletonList("dev.equo.ide:solstice:" + implVersion);
 		} else {

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeTask.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeTask.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package dev.equo.ide.gradle;
 
-import com.diffplug.common.swt.os.OS;
 import dev.equo.solstice.NestedBundles;
 import java.io.File;
+import java.io.IOException;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
@@ -43,7 +43,7 @@ public abstract class EquoIdeTask extends DefaultTask {
 	protected abstract ObjectFactory getObjectFactory();
 
 	@TaskAction
-	public void launch() {
+	public void launch() throws IOException, InterruptedException {
 		var cp = getClassPath().get();
 
 		var installDir = getInstallDir().get();
@@ -54,15 +54,10 @@ public abstract class EquoIdeTask extends DefaultTask {
 						.collect(Collectors.toList());
 		var nestedFileCollection = getObjectFactory().fileCollection().from(allNested);
 
-		getExecOperations()
-				.javaexec(
-						javaExec -> {
-							javaExec.setClasspath(cp.plus(nestedFileCollection));
-							javaExec.args("-installDir", installDir.getAbsolutePath());
-							javaExec.getMainClass().set("dev.equo.solstice.SolsticeIDE");
-							if (OS.getRunning().isMac()) {
-								javaExec.jvmArgs("-XstartOnFirstThread");
-							}
-						});
+		NestedBundles.javaExec(
+				"dev.equo.solstice.SolsticeIDE",
+				cp.plus(nestedFileCollection),
+				"-installDir",
+				installDir.getAbsolutePath());
 	}
 }

--- a/plugin-maven/build.gradle
+++ b/plugin-maven/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compileOnly "org.apache.maven.plugin-tools:maven-plugin-annotations:$VER_MAVEN_API"
 	compileOnly "org.eclipse.aether:aether-api:1.1.0"
 	implementation project(':solstice')
+	implementation 'com.diffplug.durian:durian-swt.os:4.1.1'
 	testImplementation "org.junit.jupiter:junit-jupiter:$VER_JUNIT"
 	testImplementation "org.assertj:assertj-core:$VER_ASSERTJ"
 }

--- a/plugin-maven/build.gradle
+++ b/plugin-maven/build.gradle
@@ -19,3 +19,6 @@ dependencies {
 apply from: 干.file('maven.gradle')
 apply from: 干.file('sonatype.gradle')
 apply plugin: 'de.benediktritter.maven-plugin-development'
+mavenPlugin {
+	artifactId = 'equo-ide-maven-plugin'
+}

--- a/plugin-maven/build.gradle
+++ b/plugin-maven/build.gradle
@@ -11,7 +11,9 @@ sourceCompatibility = java_compat
 targetCompatibility = java_compat
 dependencies {
 	compileOnly "org.apache.maven:maven-plugin-api:$VER_MAVEN_API"
+	compileOnly "org.apache.maven:maven-core:$VER_MAVEN_API"
 	compileOnly "org.apache.maven.plugin-tools:maven-plugin-annotations:$VER_MAVEN_API"
+	compileOnly "org.eclipse.aether:aether-api:1.1.0"
 	implementation project(':solstice')
 	testImplementation "org.junit.jupiter:junit-jupiter:$VER_JUNIT"
 	testImplementation "org.assertj:assertj-core:$VER_ASSERTJ"

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
@@ -18,8 +18,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 
-@Mojo(name = "equoIde")
-public class EquoIdeMojo extends AbstractMojo {
+@Mojo(name = "launch")
+public class LaunchMojo extends AbstractMojo {
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		System.out.println("LAUNCH THE IDE");

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
@@ -13,15 +13,99 @@
  *******************************************************************************/
 package dev.equo.ide.maven;
 
+import dev.equo.solstice.NestedBundles;
+import dev.equo.solstice.P2AsMaven;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.resolution.DependencyResult;
 
 @Mojo(name = "launch")
 public class LaunchMojo extends AbstractMojo {
+	@Component private RepositorySystem repositorySystem;
+
+	@Parameter(defaultValue = "${project.build.directory}", required = true, readonly = true)
+	private File buildDir;
+
+	@Parameter(defaultValue = "${repositorySystemSession}", required = true, readonly = true)
+	private RepositorySystemSession repositorySystemSession;
+
+	@Parameter(defaultValue = "${project.remotePluginRepositories}", required = true, readonly = true)
+	private List<RemoteRepository> repositories;
+
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
-		System.out.println("LAUNCH THE IDE");
+		try {
+			List<Dependency> deps = new ArrayList<>();
+			deps.add(
+					new Dependency(
+							new DefaultArtifact("dev.equo.ide:solstice:" + NestedBundles.solsticeVersion()),
+							null));
+			for (var coordinate : P2AsMaven.jdtDeps()) {
+				deps.add(new Dependency(new DefaultArtifact(coordinate), null));
+			}
+			CollectRequest collectRequest = new CollectRequest(deps, null, repositories);
+			DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, null);
+			DependencyResult dependencyResult =
+					repositorySystem.resolveDependencies(repositorySystemSession, dependencyRequest);
+
+			List<File> files = new ArrayList<>();
+			for (var artifact : dependencyResult.getArtifactResults()) {
+				logResolved(artifact);
+				files.add(artifact.getArtifact().getFile());
+			}
+
+			var installDir = new File(buildDir, "equoIde");
+			for (var nested : NestedBundles.inFiles(files).extractAllNestedJars(installDir)) {
+				files.add(nested.getValue());
+			}
+
+			javaExec("dev.equo.solstice.SolsticeIDE", files, "-installDir", installDir.getAbsolutePath());
+		} catch (DependencyResolutionException | IOException | InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private void logResolved(ArtifactResult artifactResult) {
+		if (getLog().isDebugEnabled()) {
+			getLog().debug("Resolved artifact: " + artifactResult);
+		}
+	}
+
+	private static int javaExec(String mainClass, List<File> cp, String... args)
+			throws IOException, InterruptedException {
+		String javaHome = System.getProperty("java.home");
+		String javaBin = javaHome + File.separator + "bin" + File.separator + "java";
+
+		List<String> command = new ArrayList<>();
+		command.add(javaBin);
+		command.add("-cp");
+		command.add(cp.stream().map(File::getAbsolutePath).collect(Collectors.joining(";")));
+		command.add(mainClass);
+		for (var arg : args) {
+			command.add(arg);
+		}
+
+		var builder = new ProcessBuilder(command);
+		Process process = builder.inheritIO().start();
+		process.waitFor();
+		return process.exitValue();
 	}
 }

--- a/plugin-maven/src/test/java/dev/equo/ide/maven/MavenPluginTest.java
+++ b/plugin-maven/src/test/java/dev/equo/ide/maven/MavenPluginTest.java
@@ -18,6 +18,6 @@ import org.junit.jupiter.api.Test;
 public class MavenPluginTest {
 	@Test
 	public void executeManually() {
-		new EquoIdeMojo();
+		new LaunchMojo();
 	}
 }

--- a/solstice/src/main/java/dev/equo/solstice/NestedBundles.java
+++ b/solstice/src/main/java/dev/equo/solstice/NestedBundles.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.JarURLConnection;
 import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -43,6 +44,19 @@ import org.osgi.framework.Constants;
  * </ul>
  */
 public abstract class NestedBundles {
+	/** Reads the version of the Solstice jar from the classpath. */
+	public static String solsticeVersion() throws IOException {
+		var solsticeJar =
+				NestedBundles.class.getResource(NestedBundles.class.getSimpleName() + ".class").toString();
+		if (!solsticeJar.startsWith("jar")) {
+			throw new IllegalArgumentException("");
+		}
+		var url = new URL(solsticeJar);
+		var jarConnection = (JarURLConnection) url.openConnection();
+		var manifest = jarConnection.getManifest();
+		return manifest.getMainAttributes().getValue("Implementation-Version");
+	}
+
 	public static final String DIR = "nested-jars";
 	private static final Attributes.Name CLASSPATH = new Attributes.Name(Constants.BUNDLE_CLASSPATH);
 

--- a/solstice/src/main/java/dev/equo/solstice/P2AsMaven.java
+++ b/solstice/src/main/java/dev/equo/solstice/P2AsMaven.java
@@ -24,7 +24,7 @@ public class P2AsMaven {
 				"org.eclipse.jetty:jetty-io:11.0.12",
 				"org.eclipse.jetty:jetty-util:11.0.12",
 				"org.eclipse.platform:org.eclipse.ant.ui:3.8.300",
-				"org.eclipse.jdt:org.eclipse.jdt.junit",
+				"org.eclipse.jdt:org.eclipse.jdt.junit:3.15.0",
 				"org.eclipse.jdt:org.eclipse.jdt.junit.core:3.11.400",
 				"org.eclipse.jdt:org.eclipse.jdt.junit5.runtime:1.1.0",
 				"org.eclipse.jdt:org.eclipse.jdt.junit.runtime:3.7.0",

--- a/solstice/src/main/java/dev/equo/solstice/P2AsMaven.java
+++ b/solstice/src/main/java/dev/equo/solstice/P2AsMaven.java
@@ -23,7 +23,6 @@ public class P2AsMaven {
 				"org.eclipse.jetty:jetty-http:11.0.12",
 				"org.eclipse.jetty:jetty-io:11.0.12",
 				"org.eclipse.jetty:jetty-util:11.0.12",
-				"org.eclipse.platform:org.eclipse.ant.ui:3.8.300",
 				"org.eclipse.jdt:org.eclipse.jdt.junit:3.15.0",
 				"org.eclipse.jdt:org.eclipse.jdt.junit.core:3.11.400",
 				"org.eclipse.jdt:org.eclipse.jdt.junit5.runtime:1.1.0",


### PR DESCRIPTION
So if our artifact is `equo-ide-maven-plugin` then our maven task should probably be `mvn equo-ide:launch`. The `equo-ide` part is fixed by the artifact id.

If we wanted, we could instead have `equo-maven-plugin` and the our maven task could be `mvn equo:ide`.

There are pros and cons to each approach, but for now I'm going to stick with `mvn equo-ide:launch`, but we have a few more days to decide if we want to switch to `mvn equo:ide`.