### PR TITLE
Gradle plugin needs to add Solstice with its transitive dependencies

### DIFF
--- a/plugin-gradle/CHANGELOG.md
+++ b/plugin-gradle/CHANGELOG.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
+### Fixed
+- Transitive dependencies of Solstice were not being added, now fixed. ([#42](https://github.com/equodev/equo-ide/pull/42))
 
 ## [0.7.0] - 2023-01-06
 ### Added

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
@@ -32,6 +32,7 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 
 	private static final String TASK_GROUP = "IDE";
 	private static final String EQUO_IDE = "equoIde";
+	private static final String EQUO_IDE_WITH_TRANSITIVES = "equoIdeWithTransitives";
 	private static final String $_OSGI_PLATFORM = "${osgi.platform}";
 
 	@Override
@@ -52,16 +53,21 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 			}
 		}
 
-		EquoIdeExtension extension = project.getExtensions().create(EQUO_IDE, EquoIdeExtension.class);
-		Configuration configuration = createConfiguration(project, EQUO_IDE);
+		EquoIdeExtension extension =
+				project.getExtensions().create(EQUO_IDE_WITH_TRANSITIVES, EquoIdeExtension.class);
+
+		Configuration withTransitives =
+				this.createConfigurationWithTransitives(project, EQUO_IDE_WITH_TRANSITIVES, true);
+		Configuration equoIde = this.createConfigurationWithTransitives(project, EQUO_IDE, false);
+		equoIde.extendsFrom(withTransitives);
 
 		project.getRepositories().mavenCentral();
 		try {
 			for (var dep : DepsResolve.resolveSolsticeAndTransitives()) {
 				if (dep instanceof File) {
-					project.getDependencies().add(EQUO_IDE, project.files(dep));
+					project.getDependencies().add(EQUO_IDE_WITH_TRANSITIVES, project.files(dep));
 				} else if (dep instanceof String) {
-					project.getDependencies().add(EQUO_IDE, dep);
+					project.getDependencies().add(EQUO_IDE_WITH_TRANSITIVES, dep);
 				} else {
 					throw new IllegalArgumentException("Expected String or File, got " + dep);
 				}
@@ -88,7 +94,7 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 									task.setDescription("Launches an Eclipse application");
 
 									task.getCaching().set(caching);
-									task.getMavenDeps().set(configuration);
+									task.getMavenDeps().set(equoIde);
 									task.getWorkspaceDir().set(workspaceDir);
 								});
 		project.afterEvaluate(
@@ -124,7 +130,8 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 						});
 	}
 
-	private Configuration createConfiguration(Project project, String name) {
+	private Configuration createConfigurationWithTransitives(
+			Project project, String name, boolean withTransitives) {
 		return project
 				.getConfigurations()
 				.create(
@@ -136,7 +143,9 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 												Bundling.BUNDLING_ATTRIBUTE,
 												project.getObjects().named(Bundling.class, Bundling.EXTERNAL));
 									});
-							config.setTransitive(false);
+							config.setCanBeConsumed(false);
+							config.setVisible(false);
+							config.setTransitive(withTransitives);
 						});
 	}
 

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
@@ -32,7 +32,7 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 
 	private static final String TASK_GROUP = "IDE";
 	private static final String EQUO_IDE = "equoIde";
-	private static final String EQUO_IDE_WITH_TRANSITIVES = "equoIdeWithTransitives";
+	private static final String WITH_TRANSITIVES = "equoIdeWithTransitives";
 	private static final String $_OSGI_PLATFORM = "${osgi.platform}";
 
 	@Override
@@ -53,21 +53,19 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 			}
 		}
 
-		EquoIdeExtension extension =
-				project.getExtensions().create(EQUO_IDE_WITH_TRANSITIVES, EquoIdeExtension.class);
-
+		EquoIdeExtension extension = project.getExtensions().create(EQUO_IDE, EquoIdeExtension.class);
 		Configuration withTransitives =
-				this.createConfigurationWithTransitives(project, EQUO_IDE_WITH_TRANSITIVES, true);
-		Configuration equoIde = this.createConfigurationWithTransitives(project, EQUO_IDE, false);
+				createConfigurationWithTransitives(project, WITH_TRANSITIVES, true);
+		Configuration equoIde = createConfigurationWithTransitives(project, EQUO_IDE, false);
 		equoIde.extendsFrom(withTransitives);
 
 		project.getRepositories().mavenCentral();
 		try {
 			for (var dep : DepsResolve.resolveSolsticeAndTransitives()) {
 				if (dep instanceof File) {
-					project.getDependencies().add(EQUO_IDE_WITH_TRANSITIVES, project.files(dep));
+					project.getDependencies().add(WITH_TRANSITIVES, project.files(dep));
 				} else if (dep instanceof String) {
-					project.getDependencies().add(EQUO_IDE_WITH_TRANSITIVES, dep);
+					project.getDependencies().add(WITH_TRANSITIVES, dep);
 				} else {
 					throw new IllegalArgumentException("Expected String or File, got " + dep);
 				}


### PR DESCRIPTION
We use our p2 resolver to handle transitives, but for Solstice we do actually need the dependency resolver to do the work.

We do this correctly in the Maven plugin since `0.7.0`.

https://github.com/equodev/equo-ide/blob/cb2e5185f9a65c27431e0037fe55d10ab00837f1/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java#L78-L80

https://github.com/equodev/equo-ide/blob/cb2e5185f9a65c27431e0037fe55d10ab00837f1/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java#L116-L119

But in the Gradle plugin every single dep was added without transitives. We got away with it in testing because we had a nifty little trick for parsing the "PluginUnderTestMetadata"

https://github.com/equodev/equo-ide/blob/cb2e5185f9a65c27431e0037fe55d10ab00837f1/plugin-gradle/src/main/java/dev/equo/ide/gradle/DepsResolve.java#L32-L54

This PR fixes that problem.