### PR TITLE
Remove explicitly atomic move

### DIFF
--- a/plugin-gradle/CHANGELOG.md
+++ b/plugin-gradle/CHANGELOG.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
+### Fixed
+- No more errors on filesystems which don't support atomic move ([#73](https://github.com/equodev/equo-ide/pull/73))
 
 ## [0.13.0] - 2023-02-05
 ### Added

--- a/plugin-maven/CHANGELOG.md
+++ b/plugin-maven/CHANGELOG.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
+### Fixed
+- No more errors on filesystems which don't support atomic move ([#73](https://github.com/equodev/equo-ide/pull/73))
 
 ## [0.13.0] - 2023-02-05
 ### Added

--- a/solstice/CHANGELOG.md
+++ b/solstice/CHANGELOG.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
+### Fixed
+- No more errors on filesystems which don't support atomic move ([#73](https://github.com/equodev/equo-ide/pull/73))
 
 ## [0.13.0] - 2023-02-05
 ### Added

--- a/solstice/src/main/java/dev/equo/solstice/p2/JarCache.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/JarCache.java
@@ -16,7 +16,6 @@ package dev.equo.solstice.p2;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okio.Okio;
@@ -53,7 +52,7 @@ class JarCache {
 					throw new IllegalArgumentException(response.code() + " at " + unit.getJarUrl());
 				}
 			}
-			Files.move(tempFile.toPath(), jar.toPath(), StandardCopyOption.ATOMIC_MOVE);
+			Files.move(tempFile.toPath(), jar.toPath());
 			return jar;
 		} else {
 			throw new IllegalStateException(


### PR DESCRIPTION
OpenJDK's (and probably Oracle's) implementation will try an atomic implementation first before proceeding to copy data.
I believe it's safe to simply remove the option and let the underlying implementation handle atomic moves.
(https://github.com/adoptium/jdk8u/blob/master/jdk/src/solaris/classes/sun/nio/fs/UnixCopyFile.java#L451, https://github.com/adoptium/jdk8u/blob/master/jdk/src/windows/classes/sun/nio/fs/WindowsFileCopy.java#L380).
Fixes #72 