### PR TITLE
Make Atomos an optional dependency

### DIFF
--- a/plugin-gradle/CHANGELOG.md
+++ b/plugin-gradle/CHANGELOG.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
+### Fixed
+- Atomos dependencies are only added when they are needed. ([#83](https://github.com/equodev/equo-ide/pull/83))
 
 ## [0.14.1] - 2023-02-13
 ### Fixed

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
@@ -91,7 +91,7 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 							project.getDependencies().add(EQUO_IDE, dep);
 						}
 						var query = extension.performQuery(caching);
-						for (var coordinate : query.getJarsNotOnMavenCentral()) {
+						for (var coordinate : query.getJarsOnMavenCentral()) {
 							ModuleDependency dep =
 									(ModuleDependency) project.getDependencies().add(EQUO_IDE, coordinate);
 							dep.setTransitive(false);

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
@@ -33,6 +33,8 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 	private static final String TASK_GROUP = "IDE";
 	private static final String EQUO_IDE = "equoIde";
 
+	private static String USE_ATOMOS_FLAG = "--use-atomos=";
+
 	@Override
 	public void apply(Project project) {
 		if (gradleIsTooOld(project)) {
@@ -75,6 +77,23 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 		project.afterEvaluate(
 				unused -> {
 					try {
+						boolean useAtomosOverride =
+								project.getGradle().getStartParameter().getTaskRequests().stream()
+										.flatMap(taskReq -> taskReq.getArgs().stream())
+										.filter(
+												arg ->
+														arg.startsWith(USE_ATOMOS_FLAG)
+																&& Boolean.parseBoolean(arg.substring(USE_ATOMOS_FLAG.length())))
+										.findAny()
+										.isPresent();
+						if (extension.useAtomos || useAtomosOverride) {
+							project
+									.getDependencies()
+									.add(EQUO_IDE, "org.apache.felix:org.apache.felix.atomos:1.0.0");
+							project
+									.getDependencies()
+									.add(EQUO_IDE, "org.apache.felix.atomos:osgi.core:8.0.0:AtomosEquinox");
+						}
 						var query = extension.performQuery(caching);
 						query
 								.getJarsOnMavenCentral()

--- a/plugin-maven/CHANGELOG.md
+++ b/plugin-maven/CHANGELOG.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
+### Fixed
+- Atomos dependencies are only added when they are needed. ([#83](https://github.com/equodev/equo-ide/pull/83))
 
 ## [0.13.2] - 2023-02-13
 ### Fixed

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
@@ -92,44 +92,18 @@ public class LaunchMojo extends AbstractP2Mojo {
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		try {
+			var caller = BuildPluginIdeMain.Caller.forProjectDir(baseDir, clean);
+
 			List<Dependency> deps = new ArrayList<>();
 			deps.add(
 					new Dependency(
 							new DefaultArtifact("dev.equo.ide:solstice:" + NestedJars.solsticeVersion()), null));
-			deps.add(
-					new Dependency(
-							new DefaultArtifact("org.slf4j:slf4j-api:1.7.36"),
-							null,
-							null,
-							EXCLUDE_ALL_TRANSITIVES));
-			deps.add(
-					new Dependency(
-							new DefaultArtifact("org.slf4j:slf4j-simple:1.7.36"),
-							null,
-							null,
-							EXCLUDE_ALL_TRANSITIVES));
-
-			var caller = BuildPluginIdeMain.Caller.forProjectDir(baseDir, clean);
-
-			if (useAtomos) {
-				deps.add(
-						new Dependency(
-								new DefaultArtifact("org.apache.felix:org.apache.felix.atomos:1.0.0"),
-								null,
-								null,
-								EXCLUDE_ALL_TRANSITIVES));
-				deps.add(
-						new Dependency(
-								new DefaultArtifact("org.apache.felix.atomos:osgi.core:8.0.0:AtomosEquinox"),
-								null,
-								null,
-								EXCLUDE_ALL_TRANSITIVES));
+			for (var dep : NestedJars.transitiveDeps(useAtomos, NestedJars.CoordFormat.MAVEN)) {
+				deps.add(new Dependency(new DefaultArtifact(dep), null, null, EXCLUDE_ALL_TRANSITIVES));
 			}
-
 			var query = super.query();
-			for (var coordinate : query.getJarsOnMavenCentral()) {
-				deps.add(
-						new Dependency(new DefaultArtifact(coordinate), null, null, EXCLUDE_ALL_TRANSITIVES));
+			for (var dep : query.getJarsOnMavenCentral()) {
+				deps.add(new Dependency(new DefaultArtifact(dep), null, null, EXCLUDE_ALL_TRANSITIVES));
 			}
 			CollectRequest collectRequest = new CollectRequest(deps, null, repositories);
 			DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, null);

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
@@ -111,6 +111,21 @@ public class LaunchMojo extends AbstractP2Mojo {
 
 			var caller = BuildPluginIdeMain.Caller.forProjectDir(baseDir, clean);
 
+			if (useAtomos) {
+				deps.add(
+						new Dependency(
+								new DefaultArtifact("org.apache.felix:org.apache.felix.atomos:1.0.0"),
+								null,
+								null,
+								EXCLUDE_ALL_TRANSITIVES));
+				deps.add(
+						new Dependency(
+								new DefaultArtifact("org.apache.felix.atomos:osgi.core:8.0.0:AtomosEquinox"),
+								null,
+								null,
+								EXCLUDE_ALL_TRANSITIVES));
+			}
+
 			var query = super.query();
 			for (var coordinate : query.getJarsOnMavenCentral()) {
 				deps.add(

--- a/solstice/CHANGELOG.md
+++ b/solstice/CHANGELOG.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
+### Fixed
+- Atomos was changed from an `implementation` dependency to `compileOnly`. ([#83](https://github.com/equodev/equo-ide/pull/83))
 
 ## [0.14.1] - 2023-02-13
 ### Fixed

--- a/solstice/build.gradle
+++ b/solstice/build.gradle
@@ -36,8 +36,8 @@ dependencies {
 	api 'com.diffplug.durian:durian-swt.os:4.1.1'
 	compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
-	implementation 'org.apache.felix:org.apache.felix.atomos:1.0.0'
-	implementation 'org.apache.felix.atomos:osgi.core:8.0.0:AtomosEquinox'
+	compileOnly 'org.apache.felix:org.apache.felix.atomos:1.0.0'
+	compileOnly 'org.apache.felix.atomos:osgi.core:8.0.0:AtomosEquinox'
 
 	// needed to navigate p2
 	implementation 'org.tukaani:xz:1.9'


### PR DESCRIPTION
By making Atomos an optional dependency, we have to add it on purpose in the build plugins.