### PR TITLE
Add QueryCache and use it when possible

### DIFF
--- a/plugin-gradle/CHANGELOG.md
+++ b/plugin-gradle/CHANGELOG.md
@@ -4,6 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
 ### Fixed
+- Massive performance gains for the `ide` and `p2deps` plugins thanks to improved caching. ([#83](https://github.com/equodev/equo-ide/pull/83))
 - Atomos dependencies are only added when they are needed. ([#83](https://github.com/equodev/equo-ide/pull/83))
 
 ## [0.14.1] - 2023-02-13

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeExtension.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeExtension.java
@@ -17,9 +17,7 @@ import dev.equo.ide.IdeHook;
 import dev.equo.ide.IdeHookBranding;
 import dev.equo.ide.IdeHookBuildship;
 import dev.equo.ide.IdeHookWelcome;
-import dev.equo.solstice.p2.P2Client;
 import dev.equo.solstice.p2.P2Model;
-import dev.equo.solstice.p2.P2Query;
 import org.gradle.api.Project;
 
 /** The DSL inside the equoIde block. */
@@ -78,7 +76,7 @@ public class EquoIdeExtension extends P2ModelDsl {
 		return ideHooks;
 	}
 
-	P2Query performQuery(P2Client.Caching caching) throws Exception {
+	P2Model prepareModel() throws Exception {
 		var modelToQuery = model;
 		if (modelToQuery.isEmpty()) {
 			modelToQuery = modelToQuery.deepCopy();
@@ -88,6 +86,6 @@ public class EquoIdeExtension extends P2ModelDsl {
 							project.getProjectDir(), project.getGradle().getStartParameter().isOffline()));
 		}
 		modelToQuery.applyNativeFilterIfNoPlatformFilter();
-		return modelToQuery.query(caching);
+		return modelToQuery;
 	}
 }

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
@@ -128,7 +128,7 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 							task.setGroup(TASK_GROUP);
 							task.setDescription("Lists the p2 dependencies of an Eclipse application");
 
-							task.getCaching().set(caching);
+							task.getClientCaching().set(caching);
 							task.getExtension().set(extension);
 						});
 	}

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
@@ -16,6 +16,7 @@ package dev.equo.ide.gradle;
 import dev.equo.solstice.NestedJars;
 import dev.equo.solstice.p2.CacheLocations;
 import dev.equo.solstice.p2.P2Client;
+import dev.equo.solstice.p2.QueryCache;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -90,7 +91,7 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 						for (var dep : NestedJars.transitiveDeps(useAtomos, NestedJars.CoordFormat.GRADLE)) {
 							project.getDependencies().add(EQUO_IDE, dep);
 						}
-						var query = extension.performQuery(caching);
+						var query = extension.prepareModel().queryUsingCache(caching, QueryCache.ALLOW);
 						for (var coordinate : query.getJarsOnMavenCentral()) {
 							ModuleDependency dep =
 									(ModuleDependency) project.getDependencies().add(EQUO_IDE, coordinate);
@@ -98,7 +99,6 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 						}
 						equoIdeTask.configure(
 								task -> {
-									task.getCaching().set(caching);
 									task.getQuery().set(query);
 									task.getMavenDeps().set(equoIde);
 									task.getProjectDir().set(project.getProjectDir());

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
@@ -91,7 +91,7 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 						for (var dep : NestedJars.transitiveDeps(useAtomos, NestedJars.CoordFormat.GRADLE)) {
 							project.getDependencies().add(EQUO_IDE, dep);
 						}
-						var query = extension.prepareModel().queryUsingCache(caching, QueryCache.ALLOW);
+						var query = extension.prepareModel().query(caching, QueryCache.ALLOW);
 						for (var coordinate : query.getJarsOnMavenCentral()) {
 							ModuleDependency dep =
 									(ModuleDependency) project.getDependencies().add(EQUO_IDE, coordinate);

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoListTask.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoListTask.java
@@ -99,6 +99,6 @@ public abstract class EquoListTask extends DefaultTask {
 					"Exactly one of --installed, --problems, --optional, --all, --detail, or --raw must be set.\n"
 							+ "`gradlew help --task equoList` for more info or visit https://github.com/equodev/equo-ide/blob/main/P2_MULTITOOL.md");
 		}
-		tool.dump(getExtension().get().prepareModel().query(getCaching().get()));
+		tool.dump(getExtension().get().prepareModel().queryRaw(getCaching().get()));
 	}
 }

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoListTask.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoListTask.java
@@ -99,6 +99,6 @@ public abstract class EquoListTask extends DefaultTask {
 					"Exactly one of --installed, --problems, --optional, --all, --detail, or --raw must be set.\n"
 							+ "`gradlew help --task equoList` for more info or visit https://github.com/equodev/equo-ide/blob/main/P2_MULTITOOL.md");
 		}
-		tool.dump(getExtension().get().performQuery(getCaching().get()));
+		tool.dump(getExtension().get().prepareModel().query(getCaching().get()));
 	}
 }

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoListTask.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoListTask.java
@@ -28,7 +28,7 @@ import org.gradle.api.tasks.options.OptionValues;
 
 public abstract class EquoListTask extends DefaultTask {
 	@Internal
-	public abstract Property<P2Client.Caching> getCaching();
+	public abstract Property<P2Client.Caching> getClientCaching();
 
 	@Internal
 	public abstract Property<EquoIdeExtension> getExtension();
@@ -99,6 +99,6 @@ public abstract class EquoListTask extends DefaultTask {
 					"Exactly one of --installed, --problems, --optional, --all, --detail, or --raw must be set.\n"
 							+ "`gradlew help --task equoList` for more info or visit https://github.com/equodev/equo-ide/blob/main/P2_MULTITOOL.md");
 		}
-		tool.dump(getExtension().get().prepareModel().queryRaw(getCaching().get()));
+		tool.dump(getExtension().get().prepareModel().queryRaw(getClientCaching().get()));
 	}
 }

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2DepsExtension.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2DepsExtension.java
@@ -13,15 +13,17 @@
  *******************************************************************************/
 package dev.equo.ide.gradle;
 
-import dev.equo.solstice.p2.P2Client;
-import dev.equo.solstice.p2.P2Model;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ModuleDependency;
+
+import dev.equo.solstice.p2.P2Client;
+import dev.equo.solstice.p2.P2Model;
 
 public class P2DepsExtension {
 	private final Project project;
@@ -48,15 +50,15 @@ public class P2DepsExtension {
 		var caching = P2ModelDsl.caching(project);
 		for (Map.Entry<String, P2Model> entry : configurations.entrySet()) {
 			String config = entry.getKey();
-			var query = entry.getValue().query(caching);
+			var query = entry.getValue().queryUsingCache(caching, false);
 			for (String mavenCoord : query.getJarsOnMavenCentral()) {
 				ModuleDependency dep = (ModuleDependency) project.getDependencies().add(config, mavenCoord);
 				dep.setTransitive(false);
 			}
 			var localFiles = new ArrayList<>();
 			try (var client = new P2Client(caching)) {
-				for (var unit : query.getJarsNotOnMavenCentral()) {
-					localFiles.add(client.download(unit));
+				for (var downloadedJar : query.getJarsNotOnMavenCentral()) {
+					localFiles.add(downloadedJar);
 				}
 			}
 			project.getDependencies().add(config, project.files(localFiles));

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2DepsExtension.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2DepsExtension.java
@@ -46,10 +46,19 @@ public class P2DepsExtension {
 	private final Map<String, P2Model> configurations = new HashMap<>();
 
 	void configure() throws Exception {
+		boolean forceRecalculate =
+				EquoIdeGradlePlugin.anyArgMatching(
+								project, arg -> arg.equals(EquoIdeGradlePlugin.CLEAN_FLAG))
+						|| EquoIdeGradlePlugin.anyArgMatching(
+								project, arg -> arg.equals(EquoIdeGradlePlugin.REFRESH_DEPENDENCIES));
+
 		var caching = P2ModelDsl.caching(project);
 		for (Map.Entry<String, P2Model> entry : configurations.entrySet()) {
 			String config = entry.getKey();
-			var query = entry.getValue().query(caching, QueryCache.ALLOW);
+			var query =
+					entry
+							.getValue()
+							.query(caching, forceRecalculate ? QueryCache.FORCE_RECALCULATE : QueryCache.ALLOW);
 			for (String mavenCoord : query.getJarsOnMavenCentral()) {
 				ModuleDependency dep = (ModuleDependency) project.getDependencies().add(config, mavenCoord);
 				dep.setTransitive(false);

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2DepsExtension.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2DepsExtension.java
@@ -13,17 +13,15 @@
  *******************************************************************************/
 package dev.equo.ide.gradle;
 
+import dev.equo.solstice.p2.P2Client;
+import dev.equo.solstice.p2.P2Model;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ModuleDependency;
-
-import dev.equo.solstice.p2.P2Client;
-import dev.equo.solstice.p2.P2Model;
 
 public class P2DepsExtension {
 	private final Project project;

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2DepsExtension.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2DepsExtension.java
@@ -15,6 +15,7 @@ package dev.equo.ide.gradle;
 
 import dev.equo.solstice.p2.P2Client;
 import dev.equo.solstice.p2.P2Model;
+import dev.equo.solstice.p2.QueryCache;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,7 +49,7 @@ public class P2DepsExtension {
 		var caching = P2ModelDsl.caching(project);
 		for (Map.Entry<String, P2Model> entry : configurations.entrySet()) {
 			String config = entry.getKey();
-			var query = entry.getValue().queryUsingCache(caching, false);
+			var query = entry.getValue().queryUsingCache(caching, QueryCache.ALLOW);
 			for (String mavenCoord : query.getJarsOnMavenCentral()) {
 				ModuleDependency dep = (ModuleDependency) project.getDependencies().add(config, mavenCoord);
 				dep.setTransitive(false);

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2DepsExtension.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2DepsExtension.java
@@ -49,7 +49,7 @@ public class P2DepsExtension {
 		var caching = P2ModelDsl.caching(project);
 		for (Map.Entry<String, P2Model> entry : configurations.entrySet()) {
 			String config = entry.getKey();
-			var query = entry.getValue().queryUsingCache(caching, QueryCache.ALLOW);
+			var query = entry.getValue().query(caching, QueryCache.ALLOW);
 			for (String mavenCoord : query.getJarsOnMavenCentral()) {
 				ModuleDependency dep = (ModuleDependency) project.getDependencies().add(config, mavenCoord);
 				dep.setTransitive(false);

--- a/plugin-maven/CHANGELOG.md
+++ b/plugin-maven/CHANGELOG.md
@@ -4,6 +4,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
 ### Fixed
+- Massive performance gains for the `ide` and `p2deps` plugins thanks to improved caching. ([#83](https://github.com/equodev/equo-ide/pull/83))
 - Launcher fixes on Windows and Linux. ([#84](https://github.com/equodev/equo-ide/pull/84) fixes [#44](https://github.com/equodev/equo-ide/issues/44))
 - Atomos dependencies are only added when they are needed. ([#83](https://github.com/equodev/equo-ide/pull/83))
 

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/AbstractP2Mojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/AbstractP2Mojo.java
@@ -17,6 +17,7 @@ import dev.equo.solstice.p2.P2Client;
 import dev.equo.solstice.p2.P2Model;
 import dev.equo.solstice.p2.P2Query;
 import dev.equo.solstice.p2.P2QueryResult;
+import dev.equo.solstice.p2.QueryCache;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -79,7 +80,7 @@ public abstract class AbstractP2Mojo extends AbstractMojo {
 	protected P2QueryResult queryUsingCache() throws MojoFailureException {
 		var model = buildModel();
 		try {
-			return model.queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, false);
+			return model.queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, QueryCache.ALLOW);
 		} catch (RuntimeException e) {
 			throw new MojoFailureException(e.getMessage(), e);
 		}

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/AbstractP2Mojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/AbstractP2Mojo.java
@@ -13,15 +13,17 @@
  *******************************************************************************/
 package dev.equo.ide.maven;
 
-import dev.equo.solstice.p2.P2Client;
-import dev.equo.solstice.p2.P2Model;
-import dev.equo.solstice.p2.P2Query;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
+
+import dev.equo.solstice.p2.P2Client;
+import dev.equo.solstice.p2.P2Model;
+import dev.equo.solstice.p2.P2Query;
 
 public abstract class AbstractP2Mojo extends AbstractMojo {
 	public static class Filter {

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/AbstractP2Mojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/AbstractP2Mojo.java
@@ -13,17 +13,15 @@
  *******************************************************************************/
 package dev.equo.ide.maven;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Parameter;
-
 import dev.equo.solstice.p2.P2Client;
 import dev.equo.solstice.p2.P2Model;
 import dev.equo.solstice.p2.P2Query;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
 
 public abstract class AbstractP2Mojo extends AbstractMojo {
 	public static class Filter {

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/AbstractP2Mojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/AbstractP2Mojo.java
@@ -16,6 +16,7 @@ package dev.equo.ide.maven;
 import dev.equo.solstice.p2.P2Client;
 import dev.equo.solstice.p2.P2Model;
 import dev.equo.solstice.p2.P2Query;
+import dev.equo.solstice.p2.P2QueryResult;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -51,7 +52,7 @@ public abstract class AbstractP2Mojo extends AbstractMojo {
 
 	@Parameter private List<String> installs = new ArrayList<>();
 
-	protected P2Query query() throws MojoFailureException {
+	private P2Model buildModel() {
 		var model = new P2Model();
 		p2repos.forEach(model::addP2Repo);
 		installs.forEach(model.getInstall()::add);
@@ -63,9 +64,22 @@ public abstract class AbstractP2Mojo extends AbstractMojo {
 			setToDefault(model);
 		}
 		model.applyNativeFilterIfNoPlatformFilter();
+	}
+
+	protected P2Query query() throws MojoFailureException {
+		var model = buildModel();
 		try {
 			return model.query(P2Client.Caching.ALLOW_OFFLINE);
 		} catch (Exception e) {
+			throw new MojoFailureException(e.getMessage(), e);
+		}
+	}
+
+	protected P2QueryResult queryUsingCache() throws MojoFailureException {
+		var model = buildModel();
+		try {
+			return model.queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, false);
+		} catch (RuntimeException e) {
 			throw new MojoFailureException(e.getMessage(), e);
 		}
 	}

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/AbstractP2Mojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/AbstractP2Mojo.java
@@ -13,16 +13,11 @@
  *******************************************************************************/
 package dev.equo.ide.maven;
 
-import dev.equo.solstice.p2.P2Client;
 import dev.equo.solstice.p2.P2Model;
-import dev.equo.solstice.p2.P2Query;
-import dev.equo.solstice.p2.P2QueryResult;
-import dev.equo.solstice.p2.QueryCache;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 
 public abstract class AbstractP2Mojo extends AbstractMojo {
@@ -53,7 +48,7 @@ public abstract class AbstractP2Mojo extends AbstractMojo {
 
 	@Parameter private List<String> installs = new ArrayList<>();
 
-	private P2Model buildModel() {
+	protected P2Model prepareModel() {
 		var model = new P2Model();
 		p2repos.forEach(model::addP2Repo);
 		installs.forEach(model.getInstall()::add);
@@ -66,24 +61,6 @@ public abstract class AbstractP2Mojo extends AbstractMojo {
 		}
 		model.applyNativeFilterIfNoPlatformFilter();
 		return model;
-	}
-
-	protected P2Query query() throws MojoFailureException {
-		var model = buildModel();
-		try {
-			return model.query(P2Client.Caching.ALLOW_OFFLINE);
-		} catch (Exception e) {
-			throw new MojoFailureException(e.getMessage(), e);
-		}
-	}
-
-	protected P2QueryResult queryUsingCache() throws MojoFailureException {
-		var model = buildModel();
-		try {
-			return model.queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, QueryCache.ALLOW);
-		} catch (RuntimeException e) {
-			throw new MojoFailureException(e.getMessage(), e);
-		}
 	}
 
 	private void setToDefault(P2Model model) {

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/AbstractP2Mojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/AbstractP2Mojo.java
@@ -64,6 +64,7 @@ public abstract class AbstractP2Mojo extends AbstractMojo {
 			setToDefault(model);
 		}
 		model.applyNativeFilterIfNoPlatformFilter();
+		return model;
 	}
 
 	protected P2Query query() throws MojoFailureException {

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
@@ -101,7 +101,7 @@ public class LaunchMojo extends AbstractP2Mojo {
 			for (var dep : NestedJars.transitiveDeps(useAtomos, NestedJars.CoordFormat.MAVEN)) {
 				deps.add(new Dependency(new DefaultArtifact(dep), null, null, EXCLUDE_ALL_TRANSITIVES));
 			}
-			var query = prepareModel().queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, QueryCache.ALLOW);
+			var query = prepareModel().query(P2Client.Caching.ALLOW_OFFLINE, QueryCache.ALLOW);
 			for (var dep : query.getJarsOnMavenCentral()) {
 				deps.add(new Dependency(new DefaultArtifact(dep), null, null, EXCLUDE_ALL_TRANSITIVES));
 			}

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
@@ -19,6 +19,8 @@ import dev.equo.ide.IdeHook;
 import dev.equo.ide.IdeHookBranding;
 import dev.equo.ide.IdeHookWelcome;
 import dev.equo.solstice.NestedJars;
+import dev.equo.solstice.p2.P2Client;
+import dev.equo.solstice.p2.QueryCache;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -99,7 +101,7 @@ public class LaunchMojo extends AbstractP2Mojo {
 			for (var dep : NestedJars.transitiveDeps(useAtomos, NestedJars.CoordFormat.MAVEN)) {
 				deps.add(new Dependency(new DefaultArtifact(dep), null, null, EXCLUDE_ALL_TRANSITIVES));
 			}
-			var query = queryUsingCache();
+			var query = prepareModel().queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, QueryCache.ALLOW);
 			for (var dep : query.getJarsOnMavenCentral()) {
 				deps.add(new Dependency(new DefaultArtifact(dep), null, null, EXCLUDE_ALL_TRANSITIVES));
 			}

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
@@ -19,8 +19,6 @@ import dev.equo.ide.IdeHook;
 import dev.equo.ide.IdeHookBranding;
 import dev.equo.ide.IdeHookWelcome;
 import dev.equo.solstice.NestedJars;
-import dev.equo.solstice.p2.P2Client;
-import dev.equo.solstice.p2.P2Unit;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -101,7 +99,7 @@ public class LaunchMojo extends AbstractP2Mojo {
 			for (var dep : NestedJars.transitiveDeps(useAtomos, NestedJars.CoordFormat.MAVEN)) {
 				deps.add(new Dependency(new DefaultArtifact(dep), null, null, EXCLUDE_ALL_TRANSITIVES));
 			}
-			var query = query();
+			var query = queryUsingCache();
 			for (var dep : query.getJarsOnMavenCentral()) {
 				deps.add(new Dependency(new DefaultArtifact(dep), null, null, EXCLUDE_ALL_TRANSITIVES));
 			}
@@ -114,10 +112,8 @@ public class LaunchMojo extends AbstractP2Mojo {
 			for (var artifact : dependencyResult.getArtifactResults()) {
 				files.add(artifact.getArtifact().getFile());
 			}
-			try (var client = new P2Client()) {
-				for (P2Unit unit : query.getJarsNotOnMavenCentral()) {
-					files.add(client.download(unit));
-				}
+			for (File downloadedJar : query.getJarsNotOnMavenCentral()) {
+				files.add(downloadedJar);
 			}
 
 			var ideHooks = new IdeHook.List();

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
@@ -101,7 +101,11 @@ public class LaunchMojo extends AbstractP2Mojo {
 			for (var dep : NestedJars.transitiveDeps(useAtomos, NestedJars.CoordFormat.MAVEN)) {
 				deps.add(new Dependency(new DefaultArtifact(dep), null, null, EXCLUDE_ALL_TRANSITIVES));
 			}
-			var query = prepareModel().query(P2Client.Caching.ALLOW_OFFLINE, QueryCache.ALLOW);
+			var query =
+					prepareModel()
+							.query(
+									P2Client.Caching.ALLOW_OFFLINE,
+									clean ? QueryCache.FORCE_RECALCULATE : QueryCache.ALLOW);
 			for (var dep : query.getJarsOnMavenCentral()) {
 				deps.add(new Dependency(new DefaultArtifact(dep), null, null, EXCLUDE_ALL_TRANSITIVES));
 			}

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
@@ -13,12 +13,19 @@
  *******************************************************************************/
 package dev.equo.ide.maven;
 
+import com.diffplug.common.swt.os.OS;
+import dev.equo.ide.BuildPluginIdeMain;
+import dev.equo.ide.IdeHook;
+import dev.equo.ide.IdeHookBranding;
+import dev.equo.ide.IdeHookWelcome;
+import dev.equo.solstice.NestedJars;
+import dev.equo.solstice.p2.P2Client;
+import dev.equo.solstice.p2.P2Unit;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
@@ -34,16 +41,6 @@ import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.resolution.DependencyResult;
-
-import com.diffplug.common.swt.os.OS;
-
-import dev.equo.ide.BuildPluginIdeMain;
-import dev.equo.ide.IdeHook;
-import dev.equo.ide.IdeHookBranding;
-import dev.equo.ide.IdeHookWelcome;
-import dev.equo.solstice.NestedJars;
-import dev.equo.solstice.p2.P2Client;
-import dev.equo.solstice.p2.P2Unit;
 
 /** Launches an Eclipse-based IDE for this project. */
 @Mojo(name = "launch")

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
@@ -13,19 +13,12 @@
  *******************************************************************************/
 package dev.equo.ide.maven;
 
-import com.diffplug.common.swt.os.OS;
-import dev.equo.ide.BuildPluginIdeMain;
-import dev.equo.ide.IdeHook;
-import dev.equo.ide.IdeHookBranding;
-import dev.equo.ide.IdeHookWelcome;
-import dev.equo.solstice.NestedJars;
-import dev.equo.solstice.p2.P2Client;
-import dev.equo.solstice.p2.P2Unit;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
@@ -41,6 +34,16 @@ import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.resolution.DependencyResult;
+
+import com.diffplug.common.swt.os.OS;
+
+import dev.equo.ide.BuildPluginIdeMain;
+import dev.equo.ide.IdeHook;
+import dev.equo.ide.IdeHookBranding;
+import dev.equo.ide.IdeHookWelcome;
+import dev.equo.solstice.NestedJars;
+import dev.equo.solstice.p2.P2Client;
+import dev.equo.solstice.p2.P2Unit;
 
 /** Launches an Eclipse-based IDE for this project. */
 @Mojo(name = "launch")
@@ -101,7 +104,7 @@ public class LaunchMojo extends AbstractP2Mojo {
 			for (var dep : NestedJars.transitiveDeps(useAtomos, NestedJars.CoordFormat.MAVEN)) {
 				deps.add(new Dependency(new DefaultArtifact(dep), null, null, EXCLUDE_ALL_TRANSITIVES));
 			}
-			var query = super.query();
+			var query = query();
 			for (var dep : query.getJarsOnMavenCentral()) {
 				deps.add(new Dependency(new DefaultArtifact(dep), null, null, EXCLUDE_ALL_TRANSITIVES));
 			}

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/ListMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/ListMojo.java
@@ -13,15 +13,13 @@
  *******************************************************************************/
 package dev.equo.ide.maven;
 
+import dev.equo.solstice.p2.ConsoleTable;
+import dev.equo.solstice.p2.P2Multitool;
 import javax.xml.transform.TransformerException;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-
-import dev.equo.solstice.p2.ConsoleTable;
-import dev.equo.solstice.p2.P2Multitool;
 
 /** Lists the p2 dependencies of an Eclipse application. */
 @Mojo(name = "list")

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/ListMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/ListMojo.java
@@ -13,13 +13,15 @@
  *******************************************************************************/
 package dev.equo.ide.maven;
 
-import dev.equo.solstice.p2.ConsoleTable;
-import dev.equo.solstice.p2.P2Multitool;
 import javax.xml.transform.TransformerException;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+
+import dev.equo.solstice.p2.ConsoleTable;
+import dev.equo.solstice.p2.P2Multitool;
 
 /** Lists the p2 dependencies of an Eclipse application. */
 @Mojo(name = "list")

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/ListMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/ListMojo.java
@@ -14,8 +14,8 @@
 package dev.equo.ide.maven;
 
 import dev.equo.solstice.p2.ConsoleTable;
+import dev.equo.solstice.p2.P2Client;
 import dev.equo.solstice.p2.P2Multitool;
-import javax.xml.transform.TransformerException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -68,9 +68,9 @@ public class ListMojo extends AbstractP2Mojo {
 							+ "`mvn help:describe -Dcmd=equo-ide:list -Ddetail` for more info or visit https://github.com/equodev/equo-ide/blob/main/P2_MULTITOOL.md");
 		}
 		try {
-			tool.dump(query());
-		} catch (TransformerException e) {
-			throw new RuntimeException(e);
+			tool.dump(prepareModel().query(P2Client.Caching.ALLOW_OFFLINE));
+		} catch (Exception e) {
+			throw new MojoFailureException(e.getMessage(), e);
 		}
 	}
 }

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/ListMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/ListMojo.java
@@ -68,7 +68,7 @@ public class ListMojo extends AbstractP2Mojo {
 							+ "`mvn help:describe -Dcmd=equo-ide:list -Ddetail` for more info or visit https://github.com/equodev/equo-ide/blob/main/P2_MULTITOOL.md");
 		}
 		try {
-			tool.dump(prepareModel().query(P2Client.Caching.ALLOW_OFFLINE));
+			tool.dump(prepareModel().queryRaw(P2Client.Caching.ALLOW_OFFLINE));
 		} catch (Exception e) {
 			throw new MojoFailureException(e.getMessage(), e);
 		}

--- a/solstice/CHANGELOG.md
+++ b/solstice/CHANGELOG.md
@@ -3,6 +3,10 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
+### Added
+- `P2QueryResult` which strips a `P2Query` down to pnly the maven coordinates and jars. ([#85](https://github.com/equodev/equo-ide/pull/85))
+	- Easy to cache, which allows us to grab massive speedup gains.
+	- Also fixed a bug which had been disabling our offline P2 metadata cache. 
 ### Fixed
 - Atomos was changed from an `implementation` dependency to `compileOnly`. ([#83](https://github.com/equodev/equo-ide/pull/83))
 

--- a/solstice/src/main/java/dev/equo/solstice/NestedJars.java
+++ b/solstice/src/main/java/dev/equo/solstice/NestedJars.java
@@ -252,7 +252,7 @@ public abstract class NestedJars {
 					new String(Base64.getEncoder().encode(md5.digest()), StandardCharsets.US_ASCII);
 			return encoded.replace('/', '-').replace('=', '-');
 		} catch (NoSuchAlgorithmException e) {
-			throw new RuntimeException(e);
+			throw Unchecked.wrap(e);
 		}
 	}
 }

--- a/solstice/src/main/java/dev/equo/solstice/ServiceRegistry.java
+++ b/solstice/src/main/java/dev/equo/solstice/ServiceRegistry.java
@@ -192,7 +192,7 @@ abstract class ServiceRegistry extends BundleContextImpl {
 			var cast = (ShimServiceFactoryReference<S>) reference;
 			return cast.factory.getService(systemBundle(), cast);
 		} else {
-			throw new RuntimeException("Unexpected class " + reference);
+			throw new IllegalArgumentException("Unexpected class " + reference);
 		}
 	}
 

--- a/solstice/src/main/java/dev/equo/solstice/p2/CacheLocations.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/CacheLocations.java
@@ -17,63 +17,69 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Optional;
 
-/** There are a few things which EquoIDE needs to cache on the developer's machine. They are described exhaustively by
- * this class.
+/**
+ * There are a few things which EquoIDE needs to cache on the developer's machine. They are
+ * described exhaustively by this class.
  *
  * <ul>
- * <li>{@link #p2metadata()}
- * <li>{@link #p2bundlePool()}
- * <li>{@link #ideWorkspaces()}
- * <li>{@link #p2Queries()}
+ *   <li>{@link #p2metadata()}
+ *   <li>{@link #p2bundlePool()}
+ *   <li>{@link #ideWorkspaces()}
+ *   <li>{@link #p2Queries()}
  * </ul>
- * <p>
- * All these values can be overridden by setting the value of the `public static override_whatever` variable.
  *
- * <p>
- * If you happen to be using Gradle, you can override these by setting any of the following in your
- * {@code ~/.gradle/gradle.properties} file.
+ * <p>All these values can be overridden by setting the value of the `public static
+ * override_whatever` variable.
+ *
+ * <p>If you happen to be using Gradle, you can override these by setting any of the following in
+ * your {@code ~/.gradle/gradle.properties} file.
  *
  * <ul>
- * <li>{@code equo_override_p2metadata}
- * <li>{@code equo_override_p2bundlePool}
- * <li>{@code equo_override_ideWorkspaces}
- * <li>{@code equo_override_p2Queries}
+ *   <li>{@code equo_override_p2metadata}
+ *   <li>{@code equo_override_p2bundlePool}
+ *   <li>{@code equo_override_ideWorkspaces}
+ *   <li>{@code equo_override_p2Queries}
  * </ul>
  */
 public class CacheLocations {
-	private CacheLocations() {
-	}
+	private CacheLocations() {}
 
 	private static final String ROOT = ".equo";
 
-	/** {@link P2Client} can use HTTP caching to speed up browsing of p2 metadata, and also to allow offline p2 queries.
+	/**
+	 * {@link P2Client} can use HTTP caching to speed up browsing of p2 metadata, and also to allow
+	 * offline p2 queries.
 	 *
-	 * <p>
-	 * Rather than downloading this metadata over and over, we only download it once, and cache the results here. */
+	 * <p>Rather than downloading this metadata over and over, we only download it once, and cache the
+	 * results here.
+	 */
 	public static File p2metadata() {
 		return defOverride(ROOT + "/p2-metadata", override_p2metadata);
 	}
 
 	public static File override_p2metadata = null;
 
-	/** Bundle pool used for caching jars and assembling disjoint eclipse installs: `~/.equo/bundle-pool`
+	/**
+	 * Bundle pool used for caching jars and assembling disjoint eclipse installs:
+	 * `~/.equo/bundle-pool`
 	 *
-	 * <p>
-	 * Oomph does this by default in the given location. */
+	 * <p>Oomph does this by default in the given location.
+	 */
 	public static File p2bundlePool() {
 		return defOverride(ROOT + "/p2-bundle-pool", override_p2bundlePool);
 	}
 
 	public static File override_p2bundlePool = null;
 
-	/** When EquoIDE creates an IDE for you, it must also create an Eclipse workspace. Unfortunately, that workspace
-	 * cannot be a subdirectory of the project directory (an eclipse limitation). This is a problem for single-project
-	 * builds.
+	/**
+	 * When EquoIDE creates an IDE for you, it must also create an Eclipse workspace. Unfortunately,
+	 * that workspace cannot be a subdirectory of the project directory (an eclipse limitation). This
+	 * is a problem for single-project builds.
 	 *
-	 * <p>
-	 * As a workaround, we put all eclipse workspaces in a central location, which is tied to their project directory.
-	 * Whenever a new workspace is created, we do a quick check to make sure there aren't any stale workspaces. If the
-	 * workspace has gone stale, we delete it. */
+	 * <p>As a workaround, we put all eclipse workspaces in a central location, which is tied to their
+	 * project directory. Whenever a new workspace is created, we do a quick check to make sure there
+	 * aren't any stale workspaces. If the workspace has gone stale, we delete it.
+	 */
 	public static File ideWorkspaces() {
 		return defOverride(ROOT + "/ide-workspaces", override_ideWorkspaces);
 	}
@@ -88,9 +94,11 @@ public class CacheLocations {
 	public static File override_p2Queries;
 
 	private static File defOverride(String userHomeRelative, File override) {
-		return Optional.ofNullable(override).orElseGet(() -> {
-			return userHome().resolve(userHomeRelative).toFile();
-		});
+		return Optional.ofNullable(override)
+				.orElseGet(
+						() -> {
+							return userHome().resolve(userHomeRelative).toFile();
+						});
 	}
 
 	private static Path userHome() {

--- a/solstice/src/main/java/dev/equo/solstice/p2/CacheLocations.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/CacheLocations.java
@@ -17,79 +17,80 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Optional;
 
-/**
- * There are a few things which EquoIDE needs to cache on the developer's machine. They are
- * described exhaustively by this class.
+/** There are a few things which EquoIDE needs to cache on the developer's machine. They are described exhaustively by
+ * this class.
  *
  * <ul>
- *   <li>{@link #p2metadata()}
- *   <li>{@link #p2bundlePool()}
- *   <li>{@link #ideWorkspaces()}
+ * <li>{@link #p2metadata()}
+ * <li>{@link #p2bundlePool()}
+ * <li>{@link #ideWorkspaces()}
+ * <li>{@link #p2Queries()}
  * </ul>
+ * <p>
+ * All these values can be overridden by setting the value of the `public static override_whatever` variable.
  *
- * All these values can be overridden by setting the value of the `public static override_whatever`
- * variable.
- *
- * <p>If you happen to be using Gradle, you can override these by setting any of the following in
- * your {@code ~/.gradle/gradle.properties} file.
+ * <p>
+ * If you happen to be using Gradle, you can override these by setting any of the following in your
+ * {@code ~/.gradle/gradle.properties} file.
  *
  * <ul>
- *   <li>{@code equo_override_p2metadata}
- *   <li>{@code equo_override_p2bundlePool}
- *   <li>{@cide equo_override_ideWorkspaces}
+ * <li>{@code equo_override_p2metadata}
+ * <li>{@code equo_override_p2bundlePool}
+ * <li>{@code equo_override_ideWorkspaces}
+ * <li>{@code equo_override_p2Queries}
  * </ul>
  */
 public class CacheLocations {
-	private CacheLocations() {}
+	private CacheLocations() {
+	}
 
 	private static final String ROOT = ".equo";
 
-	/**
-	 * {@link P2Client} can use HTTP caching to speed up browsing of p2 metadata, and also to allow
-	 * offline p2 queries.
+	/** {@link P2Client} can use HTTP caching to speed up browsing of p2 metadata, and also to allow offline p2 queries.
 	 *
-	 * <p>Rather than downloading this metadata over and over, we only download it once, and cache the
-	 * results here.
-	 */
+	 * <p>
+	 * Rather than downloading this metadata over and over, we only download it once, and cache the results here. */
 	public static File p2metadata() {
 		return defOverride(ROOT + "/p2-metadata", override_p2metadata);
 	}
 
 	public static File override_p2metadata = null;
 
-	/**
-	 * Bundle pool used for caching jars and assembling disjoint eclipse installs:
-	 * `~/.equo/bundle-pool`
+	/** Bundle pool used for caching jars and assembling disjoint eclipse installs: `~/.equo/bundle-pool`
 	 *
-	 * <p>Oomph does this by default in the given location.
-	 */
+	 * <p>
+	 * Oomph does this by default in the given location. */
 	public static File p2bundlePool() {
 		return defOverride(ROOT + "/p2-bundle-pool", override_p2bundlePool);
 	}
 
 	public static File override_p2bundlePool = null;
 
-	/**
-	 * When EquoIDE creates an IDE for you, it must also create an Eclipse workspace. Unfortunately,
-	 * that workspace cannot be a subdirectory of the project directory (an eclipse limitation). This
-	 * is a problem for single-project builds.
+	/** When EquoIDE creates an IDE for you, it must also create an Eclipse workspace. Unfortunately, that workspace
+	 * cannot be a subdirectory of the project directory (an eclipse limitation). This is a problem for single-project
+	 * builds.
 	 *
-	 * <p>As a workaround, we put all eclipse workspaces in a central location, which is tied to their
-	 * project directory. Whenever a new workspace is created, we do a quick check to make sure there
-	 * aren't any stale workspaces. If the workspace has gone stale, we delete it.
-	 */
+	 * <p>
+	 * As a workaround, we put all eclipse workspaces in a central location, which is tied to their project directory.
+	 * Whenever a new workspace is created, we do a quick check to make sure there aren't any stale workspaces. If the
+	 * workspace has gone stale, we delete it. */
 	public static File ideWorkspaces() {
 		return defOverride(ROOT + "/ide-workspaces", override_ideWorkspaces);
 	}
 
 	public static File override_ideWorkspaces = null;
 
+	/** Directory used to cache p2 queries: `~/.equo/p2-queries` */
+	public static File p2Queries() {
+		return defOverride(ROOT + "/p2-queries", override_p2Queries);
+	}
+
+	public static File override_p2Queries;
+
 	private static File defOverride(String userHomeRelative, File override) {
-		return Optional.ofNullable(override)
-				.orElseGet(
-						() -> {
-							return userHome().resolve(userHomeRelative).toFile();
-						});
+		return Optional.ofNullable(override).orElseGet(() -> {
+			return userHome().resolve(userHomeRelative).toFile();
+		});
 	}
 
 	private static Path userHome() {

--- a/solstice/src/main/java/dev/equo/solstice/p2/FileMisc.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/FileMisc.java
@@ -99,12 +99,12 @@ class FileMisc {
 	 */
 	static void retry(File input, ThrowingConsumer<File> function) {
 		long start = System.currentTimeMillis();
-		Throwable lastException;
+		Exception lastException;
 		do {
 			try {
 				function.accept(input);
 				return;
-			} catch (Throwable e) {
+			} catch (Exception e) {
 				lastException = e;
 				try {
 					Thread.sleep(1);
@@ -113,11 +113,7 @@ class FileMisc {
 				}
 			}
 		} while (System.currentTimeMillis() - start < MS_RETRY);
-		if (lastException instanceof RuntimeException) {
-			throw (RuntimeException) lastException;
-		} else {
-			throw new RuntimeException(lastException);
-		}
+		throw Unchecked.wrap(lastException);
 	}
 
 	interface ThrowingConsumer<T> {

--- a/solstice/src/main/java/dev/equo/solstice/p2/OfflineCache.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/OfflineCache.java
@@ -29,7 +29,7 @@ class OfflineCache {
 
 	OfflineCache(File rootDir) {
 		this.rootDir = rootDir;
-		if (FileMisc.readToken(rootDir, VERSION).equals(Optional.of(VERSION_VALUE))) {
+		if (!FileMisc.readToken(rootDir, VERSION).equals(Optional.of(VERSION_VALUE))) {
 			if (rootDir.exists()) {
 				FileMisc.delete(rootDir);
 			}

--- a/solstice/src/main/java/dev/equo/solstice/p2/OfflineCache.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/OfflineCache.java
@@ -67,7 +67,7 @@ class OfflineCache {
 				md5.update(middle.getBytes(StandardCharsets.UTF_8));
 				hash = md5.digest();
 			} catch (NoSuchAlgorithmException e) {
-				throw new RuntimeException(e);
+				throw Unchecked.wrap(e);
 			}
 			String hashed = Base64.getEncoder().encodeToString(hash).replace('/', '-').replace('=', '-');
 			return first + "--" + hashed + end;

--- a/solstice/src/main/java/dev/equo/solstice/p2/P2Model.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/P2Model.java
@@ -13,14 +13,13 @@
  *******************************************************************************/
 package dev.equo.solstice.p2;
 
+import com.diffplug.common.swt.os.SwtPlatform;
 import java.util.ArrayList;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.Consumer;
-
-import com.diffplug.common.swt.os.SwtPlatform;
 
 public class P2Model {
 
@@ -62,15 +61,18 @@ public class P2Model {
 		p2repo.add(p2url);
 	}
 
-	/** Applies a filter named `platform-specific-for-running` which selects artifacts for the running platform iff
-	 * there are no other platform-related filters so far. */
+	/**
+	 * Applies a filter named `platform-specific-for-running` which selects artifacts for the running
+	 * platform iff there are no other platform-related filters so far.
+	 */
 	public void applyNativeFilterIfNoPlatformFilter() {
 		boolean hasAnyPlatformFilter =
 				filters.values().stream()
 						.filter(
-								filter -> filter.props.containsKey(OSGI_OS)
-										|| filter.props.containsKey(OSGI_WS)
-										|| filter.props.containsKey(OSGI_ARCH))
+								filter ->
+										filter.props.containsKey(OSGI_OS)
+												|| filter.props.containsKey(OSGI_WS)
+												|| filter.props.containsKey(OSGI_ARCH))
 						.findAny()
 						.isPresent();
 		if (!hasAnyPlatformFilter) {

--- a/solstice/src/main/java/dev/equo/solstice/p2/P2Model.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/P2Model.java
@@ -130,7 +130,7 @@ public class P2Model {
 			queryCache.put(queryResult);
 			return queryResult;
 		} catch (Exception e) {
-			throw new RuntimeException(e);
+			throw Unchecked.wrap(e);
 		}
 	}
 

--- a/solstice/src/main/java/dev/equo/solstice/p2/P2Model.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/P2Model.java
@@ -115,17 +115,18 @@ public class P2Model {
 		return query;
 	}
 
-	public P2QueryResult queryUsingCache(P2Client.Caching cachingPolicy, boolean forceRecalculate) {
-		QueryCache queryCache = new QueryCache(CacheLocations.p2Queries(), this);
-		if (!forceRecalculate) {
+	public P2QueryResult queryUsingCache(
+			P2Client.Caching clientCachingPolicy, QueryCache queryCachingPolicy) {
+		QueryCacheOnDisk queryCache = new QueryCacheOnDisk(CacheLocations.p2Queries(), this);
+		if (!QueryCache.FORCE_RECALCULATE.equals(queryCachingPolicy)) {
 			var queryResult = queryCache.get();
 			if (queryResult != null) {
 				return queryResult;
 			}
 		}
 		try {
-			var query = query(cachingPolicy);
-			var queryResult = new P2QueryResult(query, cachingPolicy);
+			var query = query(clientCachingPolicy);
+			var queryResult = new P2QueryResult(query, clientCachingPolicy);
 			queryCache.put(queryResult);
 			return queryResult;
 		} catch (Exception e) {

--- a/solstice/src/main/java/dev/equo/solstice/p2/P2Model.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/P2Model.java
@@ -117,9 +117,9 @@ public class P2Model {
 
 	public P2QueryResult queryUsingCache(
 			P2Client.Caching clientCachingPolicy, QueryCache queryCachingPolicy) {
-		QueryCacheOnDisk queryCache = new QueryCacheOnDisk(CacheLocations.p2Queries(), this);
-		if (!QueryCache.FORCE_RECALCULATE.equals(queryCachingPolicy)) {
-			var queryResult = queryCache.get();
+		if (queryCachingPolicy.allowRead()) {
+			QueryCacheOnDisk onDisk = new QueryCacheOnDisk(CacheLocations.p2Queries(), this);
+			var queryResult = onDisk.get();
 			if (queryResult != null) {
 				return queryResult;
 			}
@@ -127,7 +127,10 @@ public class P2Model {
 		try {
 			var query = query(clientCachingPolicy);
 			var queryResult = new P2QueryResult(query, clientCachingPolicy);
-			queryCache.put(queryResult);
+			if (queryCachingPolicy.allowWrite()) {
+				QueryCacheOnDisk onDisk = new QueryCacheOnDisk(CacheLocations.p2Queries(), this);
+				onDisk.put(queryResult);
+			}
 			return queryResult;
 		} catch (Exception e) {
 			throw Unchecked.wrap(e);

--- a/solstice/src/main/java/dev/equo/solstice/p2/P2Model.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/P2Model.java
@@ -90,7 +90,7 @@ public class P2Model {
 		return deepCopy;
 	}
 
-	public P2Query query(P2Client.Caching cachingPolicy) throws Exception {
+	public P2Query queryRaw(P2Client.Caching cachingPolicy) throws Exception {
 		validateFilters();
 		var session = new P2Session();
 		try (var client = new P2Client(cachingPolicy)) {
@@ -115,8 +115,7 @@ public class P2Model {
 		return query;
 	}
 
-	public P2QueryResult queryUsingCache(
-			P2Client.Caching clientCachingPolicy, QueryCache queryCachingPolicy) {
+	public P2QueryResult query(P2Client.Caching clientCachingPolicy, QueryCache queryCachingPolicy) {
 		if (queryCachingPolicy.allowRead()) {
 			QueryCacheOnDisk onDisk = new QueryCacheOnDisk(CacheLocations.p2Queries(), this);
 			var queryResult = onDisk.get();
@@ -125,7 +124,7 @@ public class P2Model {
 			}
 		}
 		try {
-			var query = query(clientCachingPolicy);
+			var query = queryRaw(clientCachingPolicy);
 			var queryResult = new P2QueryResult(query, clientCachingPolicy);
 			if (queryCachingPolicy.allowWrite()) {
 				QueryCacheOnDisk onDisk = new QueryCacheOnDisk(CacheLocations.p2Queries(), this);

--- a/solstice/src/main/java/dev/equo/solstice/p2/P2Query.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/P2Query.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package dev.equo.solstice.p2;
 
-import com.diffplug.common.swt.os.SwtPlatform;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -23,10 +22,10 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-/**
- * Follows the dependency information of a set of {@link dev.equo.solstice.p2.P2Unit} so that they
- * can be installed from maven or directly from p2 if necessary.
- */
+import com.diffplug.common.swt.os.SwtPlatform;
+
+/** Follows the dependency information of a set of {@link dev.equo.solstice.p2.P2Unit} so that they can be installed
+ * from maven or directly from p2 if necessary. */
 public class P2Query {
 	private P2Session session;
 
@@ -112,10 +111,8 @@ public class P2Query {
 		return installed.get(id);
 	}
 
-	/**
-	 * Returns every unit available in the parent session with the given id, possibly multiple
-	 * versions of the same id.
-	 */
+	/** Returns every unit available in the parent session with the given id, possibly multiple versions of the same
+	 * id. */
 	public List<P2Unit> getAllAvailableUnitsById(String id) {
 		return session.units.stream().filter(u -> u.id.equals(id)).collect(Collectors.toList());
 	}
@@ -277,10 +274,7 @@ public class P2Query {
 		return installed.get(unit.getId()) == unit;
 	}
 
-	/**
-	 * Returns all optional requirements which were not installed, along with every unit which
-	 * optionally wanted it.
-	 */
+	/** Returns all optional requirements which were not installed, along with every unit which optionally wanted it. */
 	public Map<P2Session.Requirement, Set<P2Unit>> getOptionalRequirementsNotInstalled() {
 		var iter = optionalSoMaybeNotInstalled.entrySet().iterator();
 		while (iter.hasNext()) {

--- a/solstice/src/main/java/dev/equo/solstice/p2/P2Query.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/P2Query.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package dev.equo.solstice.p2;
 
+import com.diffplug.common.swt.os.SwtPlatform;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,10 +23,10 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import com.diffplug.common.swt.os.SwtPlatform;
-
-/** Follows the dependency information of a set of {@link dev.equo.solstice.p2.P2Unit} so that they can be installed
- * from maven or directly from p2 if necessary. */
+/**
+ * Follows the dependency information of a set of {@link dev.equo.solstice.p2.P2Unit} so that they
+ * can be installed from maven or directly from p2 if necessary.
+ */
 public class P2Query {
 	private P2Session session;
 
@@ -111,8 +112,10 @@ public class P2Query {
 		return installed.get(id);
 	}
 
-	/** Returns every unit available in the parent session with the given id, possibly multiple versions of the same
-	 * id. */
+	/**
+	 * Returns every unit available in the parent session with the given id, possibly multiple
+	 * versions of the same id.
+	 */
 	public List<P2Unit> getAllAvailableUnitsById(String id) {
 		return session.units.stream().filter(u -> u.id.equals(id)).collect(Collectors.toList());
 	}
@@ -274,7 +277,10 @@ public class P2Query {
 		return installed.get(unit.getId()) == unit;
 	}
 
-	/** Returns all optional requirements which were not installed, along with every unit which optionally wanted it. */
+	/**
+	 * Returns all optional requirements which were not installed, along with every unit which
+	 * optionally wanted it.
+	 */
 	public Map<P2Session.Requirement, Set<P2Unit>> getOptionalRequirementsNotInstalled() {
 		var iter = optionalSoMaybeNotInstalled.entrySet().iterator();
 		while (iter.hasNext()) {

--- a/solstice/src/main/java/dev/equo/solstice/p2/P2QueryResult.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/P2QueryResult.java
@@ -1,0 +1,35 @@
+package dev.equo.solstice.p2;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class P2QueryResult implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private List<String> mavenCoordinates;
+	private List<File> downloadedP2Jars;
+
+	P2QueryResult(P2Query query, P2Client.Caching cachingPolicy) {
+		this.mavenCoordinates = query.getJarsOnMavenCentral();
+		this.downloadedP2Jars = new ArrayList<>();
+		try (var client = new P2Client(cachingPolicy)) {
+			for (P2Unit unit : query.getJarsNotOnMavenCentral()) {
+				downloadedP2Jars.add(client.download(unit));
+			}
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public List<String> getJarsOnMavenCentral() {
+		return new ArrayList<>(mavenCoordinates);
+	}
+
+	public List<File> getJarsNotOnMavenCentral() {
+		return new ArrayList<>(downloadedP2Jars);
+	}
+}

--- a/solstice/src/main/java/dev/equo/solstice/p2/P2QueryResult.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/P2QueryResult.java
@@ -35,7 +35,7 @@ public class P2QueryResult implements Serializable {
 				downloadedP2Jars.add(client.download(unit));
 			}
 		} catch (IOException e) {
-			throw new RuntimeException(e);
+			throw Unchecked.wrap(e);
 		}
 	}
 

--- a/solstice/src/main/java/dev/equo/solstice/p2/P2QueryResult.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/P2QueryResult.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class P2QueryResult implements Serializable {
@@ -27,7 +28,7 @@ public class P2QueryResult implements Serializable {
 	private List<File> downloadedP2Jars;
 
 	P2QueryResult(P2Query query, P2Client.Caching cachingPolicy) {
-		this.mavenCoordinates = query.getJarsOnMavenCentral();
+		this.mavenCoordinates = new ArrayList<>(query.getJarsOnMavenCentral());
 		this.downloadedP2Jars = new ArrayList<>();
 		try (var client = new P2Client(cachingPolicy)) {
 			for (P2Unit unit : query.getJarsNotOnMavenCentral()) {
@@ -39,10 +40,10 @@ public class P2QueryResult implements Serializable {
 	}
 
 	public List<String> getJarsOnMavenCentral() {
-		return new ArrayList<>(mavenCoordinates);
+		return Collections.unmodifiableList(mavenCoordinates);
 	}
 
 	public List<File> getJarsNotOnMavenCentral() {
-		return new ArrayList<>(downloadedP2Jars);
+		return Collections.unmodifiableList(downloadedP2Jars);
 	}
 }

--- a/solstice/src/main/java/dev/equo/solstice/p2/P2QueryResult.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/P2QueryResult.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2022 EquoTech, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     EquoTech, Inc. - initial API and implementation
+ *******************************************************************************/
 package dev.equo.solstice.p2;
 
 import java.io.File;

--- a/solstice/src/main/java/dev/equo/solstice/p2/P2Session.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/P2Session.java
@@ -303,7 +303,7 @@ public class P2Session {
 					try {
 						return FilterImpl.newInstance(f);
 					} catch (InvalidSyntaxException e) {
-						throw new RuntimeException(e);
+						throw Unchecked.wrap(e);
 					}
 				});
 	}

--- a/solstice/src/main/java/dev/equo/solstice/p2/QueryCache.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/QueryCache.java
@@ -14,6 +14,15 @@
 package dev.equo.solstice.p2;
 
 public enum QueryCache {
+	NONE,
 	ALLOW,
-	FORCE_RECALCULATE
+	FORCE_RECALCULATE;
+
+	public boolean allowRead() {
+		return this == ALLOW;
+	}
+
+	public boolean allowWrite() {
+		return this == ALLOW || this == FORCE_RECALCULATE;
+	}
 }

--- a/solstice/src/main/java/dev/equo/solstice/p2/QueryCache.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/QueryCache.java
@@ -1,11 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2022 EquoTech, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     EquoTech, Inc. - initial API and implementation
+ *******************************************************************************/
 package dev.equo.solstice.p2;
 
+import dev.equo.solstice.SerializableMisc;
 import java.io.File;
 import java.util.Optional;
-
 import javax.annotation.Nullable;
-
-import dev.equo.solstice.SerializableMisc;
 
 public class QueryCache {
 	final File rootDir;
@@ -42,5 +53,4 @@ public class QueryCache {
 		FileMisc.mkdirs(dir);
 		SerializableMisc.toFile(query, new File(dir, CONTENT));
 	}
-
 }

--- a/solstice/src/main/java/dev/equo/solstice/p2/QueryCache.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/QueryCache.java
@@ -1,0 +1,46 @@
+package dev.equo.solstice.p2;
+
+import java.io.File;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import dev.equo.solstice.SerializableMisc;
+
+public class QueryCache {
+	final File rootDir;
+	final String key;
+
+	QueryCache(File rootDir, P2Model model) {
+		this.rootDir = rootDir;
+		this.key = String.valueOf(model.hashCode());
+		if (!FileMisc.readToken(rootDir, VERSION).equals(Optional.of(VERSION_VALUE))) {
+			if (rootDir.exists()) {
+				FileMisc.delete(rootDir);
+			}
+			FileMisc.mkdirs(rootDir);
+			FileMisc.writeToken(rootDir, VERSION, VERSION_VALUE);
+		}
+	}
+
+	private static final String VERSION = "version";
+	private static final String VERSION_VALUE = "1";
+
+	private static final String CONTENT = "content";
+
+	public @Nullable P2QueryResult get() {
+		var dir = new File(rootDir, OfflineCache.filenameSafe(key));
+		if (dir.isDirectory()) {
+			return SerializableMisc.fromFile(P2QueryResult.class, new File(dir, CONTENT));
+		} else {
+			return null;
+		}
+	}
+
+	public void put(P2QueryResult query) {
+		var dir = new File(rootDir, OfflineCache.filenameSafe(key));
+		FileMisc.mkdirs(dir);
+		SerializableMisc.toFile(query, new File(dir, CONTENT));
+	}
+
+}

--- a/solstice/src/main/java/dev/equo/solstice/p2/QueryCache.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/QueryCache.java
@@ -13,44 +13,7 @@
  *******************************************************************************/
 package dev.equo.solstice.p2;
 
-import dev.equo.solstice.SerializableMisc;
-import java.io.File;
-import java.util.Optional;
-import javax.annotation.Nullable;
-
-public class QueryCache {
-	final File rootDir;
-	final String key;
-
-	QueryCache(File rootDir, P2Model model) {
-		this.rootDir = rootDir;
-		this.key = String.valueOf(model.hashCode());
-		if (!FileMisc.readToken(rootDir, VERSION).equals(Optional.of(VERSION_VALUE))) {
-			if (rootDir.exists()) {
-				FileMisc.delete(rootDir);
-			}
-			FileMisc.mkdirs(rootDir);
-			FileMisc.writeToken(rootDir, VERSION, VERSION_VALUE);
-		}
-	}
-
-	private static final String VERSION = "version";
-	private static final String VERSION_VALUE = "1";
-
-	private static final String CONTENT = "content";
-
-	public @Nullable P2QueryResult get() {
-		var dir = new File(rootDir, OfflineCache.filenameSafe(key));
-		if (dir.isDirectory()) {
-			return SerializableMisc.fromFile(P2QueryResult.class, new File(dir, CONTENT));
-		} else {
-			return null;
-		}
-	}
-
-	public void put(P2QueryResult query) {
-		var dir = new File(rootDir, OfflineCache.filenameSafe(key));
-		FileMisc.mkdirs(dir);
-		SerializableMisc.toFile(query, new File(dir, CONTENT));
-	}
+public enum QueryCache {
+	ALLOW,
+	FORCE_RECALCULATE
 }

--- a/solstice/src/main/java/dev/equo/solstice/p2/QueryCacheOnDisk.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/QueryCacheOnDisk.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2022 EquoTech, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     EquoTech, Inc. - initial API and implementation
+ *******************************************************************************/
+package dev.equo.solstice.p2;
+
+import dev.equo.solstice.SerializableMisc;
+import java.io.File;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+class QueryCacheOnDisk {
+	final File rootDir;
+	final String key;
+
+	QueryCacheOnDisk(File rootDir, P2Model model) {
+		this.rootDir = rootDir;
+		this.key = String.valueOf(model.hashCode());
+		if (!FileMisc.readToken(rootDir, VERSION).equals(Optional.of(VERSION_VALUE))) {
+			if (rootDir.exists()) {
+				FileMisc.delete(rootDir);
+			}
+			FileMisc.mkdirs(rootDir);
+			FileMisc.writeToken(rootDir, VERSION, VERSION_VALUE);
+		}
+	}
+
+	private static final String VERSION = "version";
+	private static final String VERSION_VALUE = "1";
+
+	private static final String CONTENT = "content";
+
+	public @Nullable P2QueryResult get() {
+		var dir = new File(rootDir, OfflineCache.filenameSafe(key));
+		if (dir.isDirectory()) {
+			return SerializableMisc.fromFile(P2QueryResult.class, new File(dir, CONTENT));
+		} else {
+			return null;
+		}
+	}
+
+	public void put(P2QueryResult query) {
+		var dir = new File(rootDir, OfflineCache.filenameSafe(key));
+		FileMisc.mkdirs(dir);
+		SerializableMisc.toFile(query, new File(dir, CONTENT));
+	}
+}

--- a/solstice/src/main/java/dev/equo/solstice/p2/Unchecked.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/Unchecked.java
@@ -17,4 +17,12 @@ class Unchecked {
 	interface ThrowingConsumer<T> {
 		void accept(T input) throws Exception;
 	}
+
+	static RuntimeException wrap(Exception e) {
+		if (e instanceof RuntimeException) {
+			return (RuntimeException) e;
+		} else {
+			return new RuntimeException(e);
+		}
+	}
 }

--- a/solstice/src/test/java/dev/equo/solstice/p2/P2ModelTest.java
+++ b/solstice/src/test/java/dev/equo/solstice/p2/P2ModelTest.java
@@ -68,13 +68,12 @@ public class P2ModelTest {
 		model.addP2Repo("https://download.eclipse.org/eclipse/updates/4.26/");
 		model.getInstall().add("org.eclipse.releng.java.languages.categoryIU");
 		model.getInstall().add("org.eclipse.platform.ide.categoryIU");
-		var result =
-				model.queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, QueryCache.FORCE_RECALCULATE);
+		var result = model.query(P2Client.Caching.ALLOW_OFFLINE, QueryCache.FORCE_RECALCULATE);
 		var mavenCentralCoordinates = result.getJarsOnMavenCentral();
 		var downloadedJars = result.getJarsNotOnMavenCentral();
 		Assertions.assertFalse(mavenCentralCoordinates.isEmpty());
 		Assertions.assertFalse(downloadedJars.isEmpty());
-		result = model.queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, QueryCache.ALLOW);
+		result = model.query(P2Client.Caching.ALLOW_OFFLINE, QueryCache.ALLOW);
 		Assertions.assertEquals(result.getJarsOnMavenCentral(), mavenCentralCoordinates);
 		Assertions.assertEquals(result.getJarsNotOnMavenCentral(), downloadedJars);
 	}

--- a/solstice/src/test/java/dev/equo/solstice/p2/P2ModelTest.java
+++ b/solstice/src/test/java/dev/equo/solstice/p2/P2ModelTest.java
@@ -68,12 +68,13 @@ public class P2ModelTest {
 		model.addP2Repo("https://download.eclipse.org/eclipse/updates/4.26/");
 		model.getInstall().add("org.eclipse.releng.java.languages.categoryIU");
 		model.getInstall().add("org.eclipse.platform.ide.categoryIU");
-		var result = model.queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, false);
+		var result =
+				model.queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, QueryCache.FORCE_RECALCULATE);
 		var mavenCentralCoordinates = result.getJarsOnMavenCentral();
 		var downloadedJars = result.getJarsNotOnMavenCentral();
 		Assertions.assertFalse(mavenCentralCoordinates.isEmpty());
 		Assertions.assertFalse(downloadedJars.isEmpty());
-		result = model.queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, false);
+		result = model.queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, QueryCache.ALLOW);
 		Assertions.assertEquals(result.getJarsOnMavenCentral(), mavenCentralCoordinates);
 		Assertions.assertEquals(result.getJarsNotOnMavenCentral(), downloadedJars);
 	}

--- a/solstice/src/test/java/dev/equo/solstice/p2/P2ModelTest.java
+++ b/solstice/src/test/java/dev/equo/solstice/p2/P2ModelTest.java
@@ -13,12 +13,14 @@
  *******************************************************************************/
 package dev.equo.solstice.p2;
 
-import au.com.origin.snapshots.Expect;
-import au.com.origin.snapshots.junit5.SnapshotExtension;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({SnapshotExtension.class})
+import au.com.origin.snapshots.Expect;
+import au.com.origin.snapshots.junit5.SnapshotExtension;
+
+@ExtendWith({ SnapshotExtension.class })
 public class P2ModelTest {
 	@Test
 	public void toString(Expect expect) {
@@ -59,5 +61,22 @@ public class P2ModelTest {
 		filter.getProps().put("green", "0,255,0");
 		filter.getProps().put("blue", "0,0,255");
 		expect.scenario("filter props multiple").toMatchSnapshot(filter.toString());
+	}
+
+	@Test
+	public void cache() {
+		var model = new P2Model();
+		model.addP2Repo("https://download.eclipse.org/eclipse/updates/4.26/");
+		model.getInstall().add("org.eclipse.releng.java.languages.categoryIU");
+		model.getInstall().add("org.eclipse.platform.ide.categoryIU");
+		var result = model.queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, false);
+		var mavenCentralCoordinates = result.getJarsOnMavenCentral();
+		var downloadedJars = result.getJarsNotOnMavenCentral();
+		Assertions.assertFalse(mavenCentralCoordinates.isEmpty());
+		Assertions.assertFalse(downloadedJars.isEmpty());
+		result = model.queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, false);
+		Assertions.assertEquals(result.getJarsOnMavenCentral(), mavenCentralCoordinates);
+		Assertions.assertEquals(result.getJarsNotOnMavenCentral(), downloadedJars);
+
 	}
 }

--- a/solstice/src/test/java/dev/equo/solstice/p2/P2ModelTest.java
+++ b/solstice/src/test/java/dev/equo/solstice/p2/P2ModelTest.java
@@ -13,14 +13,13 @@
  *******************************************************************************/
 package dev.equo.solstice.p2;
 
+import au.com.origin.snapshots.Expect;
+import au.com.origin.snapshots.junit5.SnapshotExtension;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import au.com.origin.snapshots.Expect;
-import au.com.origin.snapshots.junit5.SnapshotExtension;
-
-@ExtendWith({ SnapshotExtension.class })
+@ExtendWith({SnapshotExtension.class})
 public class P2ModelTest {
 	@Test
 	public void toString(Expect expect) {
@@ -77,6 +76,5 @@ public class P2ModelTest {
 		result = model.queryUsingCache(P2Client.Caching.ALLOW_OFFLINE, false);
 		Assertions.assertEquals(result.getJarsOnMavenCentral(), mavenCentralCoordinates);
 		Assertions.assertEquals(result.getJarsNotOnMavenCentral(), downloadedJars);
-
 	}
 }


### PR DESCRIPTION
Adds serialization of important data in P2Query and uses that when possible.

The integration with the Maven plugin is still missing and the added tests were just a quick and dirty way of trying this out but maybe adapting them a bit they're still useful.

Merging this PR should fix #52 