### PR TITLE
Only download dependencies when `equoIde` is going to actually run

### DIFF
--- a/plugin-gradle/CHANGELOG.md
+++ b/plugin-gradle/CHANGELOG.md
@@ -3,6 +3,9 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
+### Added
+- `equoIde` now downloads its dependencies only if it is called directly. This means that CI builds don't need to download IDE dependencies. ([#89]https://github.com/equodev/equo-ide/pull/89))
+  - Also, `equoIde` no longer adds `mavenCentral()` automatically.
 
 ## [0.15.0] - 2023-02-19
 ### Added

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
@@ -73,7 +73,6 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 							task.getExtension().set(extension);
 						});
 
-		project.getRepositories().mavenCentral();
 		try {
 			for (var dep : DepsResolve.resolveSolsticeAndTransitives()) {
 				if (dep instanceof File) {

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
@@ -15,7 +15,6 @@ package dev.equo.ide.gradle;
 
 import dev.equo.solstice.NestedJars;
 import dev.equo.solstice.p2.CacheLocations;
-import dev.equo.solstice.p2.P2Client;
 import dev.equo.solstice.p2.QueryCache;
 import java.io.File;
 import java.io.IOException;
@@ -67,7 +66,7 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 			throw new GradleException("Unable to determine solstice version", e);
 		}
 
-		P2Client.Caching caching = P2ModelDsl.caching(project);
+		var clientCaching = P2ModelDsl.clientCaching(project);
 		var equoIdeTask =
 				project
 						.getTasks()
@@ -98,7 +97,7 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 								extension
 										.prepareModel()
 										.query(
-												caching,
+												clientCaching,
 												forceRecalculate ? QueryCache.FORCE_RECALCULATE : QueryCache.ALLOW);
 						for (var coordinate : query.getJarsOnMavenCentral()) {
 							ModuleDependency dep =
@@ -127,7 +126,7 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 							task.setGroup(TASK_GROUP);
 							task.setDescription("Lists the p2 dependencies of an Eclipse application");
 
-							task.getClientCaching().set(caching);
+							task.getClientCaching().set(clientCaching);
 							task.getExtension().set(extension);
 						});
 	}

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
@@ -93,8 +93,7 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 						}
 
 						boolean forceRecalculate =
-								anyArgMatching(project, arg -> arg.equals(CLEAN_FLAG))
-										|| anyArgMatching(project, arg -> arg.equals(REFRESH_DEPENDENCIES));
+								anyArgEquals(project, CLEAN_FLAG) || anyArgEquals(project, REFRESH_DEPENDENCIES);
 						var query =
 								extension
 										.prepareModel()
@@ -139,6 +138,10 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 				.filter(predicate)
 				.findAny()
 				.isPresent();
+	}
+
+	static boolean anyArgEquals(Project project, String arg) {
+		return anyArgMatching(project, a -> a.equals(arg));
 	}
 
 	private Configuration createConfigurationWithTransitives(Project project, String name) {

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
@@ -47,6 +47,8 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 
 		var extension = project.getExtensions().create(EQUO_IDE, EquoIdeExtension.class, project);
 		extension.branding.title(project.getName());
+
+		boolean equoIdeWasCalledDirectly = anyArgEquals(project, EQUO_IDE);
 		var equoIde = createConfiguration(project, EQUO_IDE);
 		var equoIdeTask =
 				project
@@ -57,6 +59,7 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 								task -> {
 									task.setGroup(TASK_GROUP);
 									task.setDescription("Launches an Eclipse-based IDE for this project");
+									task.getEquoIdeWasCalledDirectly().set(equoIdeWasCalledDirectly);
 								});
 		project
 				.getTasks()
@@ -70,8 +73,7 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 							task.getClientCaching().set(P2ModelDsl.clientCaching(project));
 							task.getExtension().set(extension);
 						});
-
-		if (anyArgEquals(project, EQUO_IDE) || anyArgEquals(project, EQUO_LIST)) {
+		if (equoIdeWasCalledDirectly) {
 			configureEquoTasks(project, extension, equoIde, equoIdeTask);
 		}
 	}

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
@@ -15,7 +15,6 @@ package dev.equo.ide.gradle;
 
 import dev.equo.solstice.NestedJars;
 import dev.equo.solstice.p2.CacheLocations;
-import dev.equo.solstice.p2.QueryCache;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -36,8 +35,6 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 	private static final String EQUO_IDE = "equoIde";
 
 	private static final String USE_ATOMOS_FLAG = "--use-atomos=";
-	static final String CLEAN_FLAG = "--clean";
-	static final String REFRESH_DEPENDENCIES = "--refresh-dependencies";
 
 	@Override
 	public void apply(Project project) {
@@ -90,15 +87,8 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 						for (var dep : NestedJars.transitiveDeps(useAtomos, NestedJars.CoordFormat.GRADLE)) {
 							project.getDependencies().add(EQUO_IDE, dep);
 						}
-
-						boolean forceRecalculate =
-								anyArgEquals(project, CLEAN_FLAG) || anyArgEquals(project, REFRESH_DEPENDENCIES);
 						var query =
-								extension
-										.prepareModel()
-										.query(
-												clientCaching,
-												forceRecalculate ? QueryCache.FORCE_RECALCULATE : QueryCache.ALLOW);
+								extension.prepareModel().query(clientCaching, P2ModelDsl.queryCaching(project));
 						for (var coordinate : query.getJarsOnMavenCentral()) {
 							ModuleDependency dep =
 									(ModuleDependency) project.getDependencies().add(EQUO_IDE, coordinate);

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeTask.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeTask.java
@@ -116,13 +116,20 @@ public abstract class EquoIdeTask extends DefaultTask {
 		}
 		var caller = BuildPluginIdeMain.Caller.forProjectDir(getProjectDir().get(), clean);
 
-		var jarsNotOnMaven =
-				getObjectFactory().fileCollection().from(getQuery().get().getJarsNotOnMavenCentral());
-		var p2AndMavenDeps = jarsNotOnMaven.plus(getMavenDeps().get());
 		var classpath = new ArrayList<File>();
-		p2AndMavenDeps.forEach(classpath::add);
+		try {
+			var jarsNotOnMaven =
+					getObjectFactory().fileCollection().from(getQuery().get().getJarsNotOnMavenCentral());
+			var p2AndMavenDeps = jarsNotOnMaven.plus(getMavenDeps().get());
+			p2AndMavenDeps.forEach(classpath::add);
+		} catch (Exception e) {
+			throw new GradleException(
+					"Unable to download Equo dependencies. You probably need to add\n"
+							+ "`repositories { mavenCentral() }` or something similar to your `build.gradle`.",
+					e);
+		}
 
-		if (p2AndMavenDeps.isEmpty()) {
+		if (classpath.isEmpty()) {
 			throw new GradleException(
 					"EquoIDE has nothing to install!\n\n"
 							+ "We recommend starting with this:\n"

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeTask.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeTask.java
@@ -42,6 +42,9 @@ public abstract class EquoIdeTask extends DefaultTask {
 	@Internal
 	public abstract Property<Boolean> getUseAtomos();
 
+	@Internal
+	public abstract Property<Boolean> getEquoIdeWasCalledDirectly();
+
 	@Internal IdeHook.List ideHooks;
 
 	public IdeHook.List getIdeHooks() {
@@ -107,6 +110,10 @@ public abstract class EquoIdeTask extends DefaultTask {
 
 	@TaskAction
 	public void launch() throws IOException, InterruptedException {
+		if (!getEquoIdeWasCalledDirectly().get()) {
+			throw new GradleException(
+					"You must call `equoIde` directly, you cannot call a task which depends on `equoIde`.");
+		}
 		var caller = BuildPluginIdeMain.Caller.forProjectDir(getProjectDir().get(), clean);
 
 		var jarsNotOnMaven =

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2DepsExtension.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2DepsExtension.java
@@ -52,19 +52,21 @@ public class P2DepsExtension {
 				EquoIdeGradlePlugin.anyArgEquals(project, EquoIdeGradlePlugin.CLEAN_FLAG)
 						|| EquoIdeGradlePlugin.anyArgEquals(project, EquoIdeGradlePlugin.REFRESH_DEPENDENCIES);
 
-		var caching = P2ModelDsl.caching(project);
+		var clientCaching = P2ModelDsl.clientCaching(project);
 		for (Map.Entry<String, P2Model> entry : configurations.entrySet()) {
 			String config = entry.getKey();
 			var query =
 					entry
 							.getValue()
-							.query(caching, forceRecalculate ? QueryCache.FORCE_RECALCULATE : QueryCache.ALLOW);
+							.query(
+									clientCaching,
+									forceRecalculate ? QueryCache.FORCE_RECALCULATE : QueryCache.ALLOW);
 			for (String mavenCoord : query.getJarsOnMavenCentral()) {
 				ModuleDependency dep = (ModuleDependency) project.getDependencies().add(config, mavenCoord);
 				dep.setTransitive(false);
 			}
 			var localFiles = new ArrayList<>();
-			try (var client = new P2Client(caching)) {
+			try (var client = new P2Client(clientCaching)) {
 				for (var downloadedJar : query.getJarsNotOnMavenCentral()) {
 					localFiles.add(downloadedJar);
 				}

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2DepsExtension.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2DepsExtension.java
@@ -49,10 +49,8 @@ public class P2DepsExtension {
 
 	void configure() throws Exception {
 		boolean forceRecalculate =
-				EquoIdeGradlePlugin.anyArgMatching(
-								project, arg -> arg.equals(EquoIdeGradlePlugin.CLEAN_FLAG))
-						|| EquoIdeGradlePlugin.anyArgMatching(
-								project, arg -> arg.equals(EquoIdeGradlePlugin.REFRESH_DEPENDENCIES));
+				EquoIdeGradlePlugin.anyArgEquals(project, EquoIdeGradlePlugin.CLEAN_FLAG)
+						|| EquoIdeGradlePlugin.anyArgEquals(project, EquoIdeGradlePlugin.REFRESH_DEPENDENCIES);
 
 		var caching = P2ModelDsl.caching(project);
 		for (Map.Entry<String, P2Model> entry : configurations.entrySet()) {

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2ModelDsl.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2ModelDsl.java
@@ -15,6 +15,7 @@ package dev.equo.ide.gradle;
 
 import dev.equo.solstice.p2.P2Client;
 import dev.equo.solstice.p2.P2Model;
+import dev.equo.solstice.p2.QueryCache;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 
@@ -60,4 +61,14 @@ public class P2ModelDsl {
 	static P2Client.Caching clientCaching(Project project) {
 		return P2Client.Caching.defaultIfOfflineIs(project.getGradle().getStartParameter().isOffline());
 	}
+
+	static QueryCache queryCaching(Project project) {
+		boolean forceRecalculate =
+				EquoIdeGradlePlugin.anyArgEquals(project, CLEAN_FLAG)
+						|| EquoIdeGradlePlugin.anyArgEquals(project, REFRESH_DEPENDENCIES);
+		return forceRecalculate ? QueryCache.FORCE_RECALCULATE : QueryCache.ALLOW;
+	}
+
+	private static final String CLEAN_FLAG = "--clean";
+	private static final String REFRESH_DEPENDENCIES = "--refresh-dependencies";
 }

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2ModelDsl.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2ModelDsl.java
@@ -57,7 +57,7 @@ public class P2ModelDsl {
 		model.getFilters().clear();
 	}
 
-	static P2Client.Caching caching(Project project) {
+	static P2Client.Caching clientCaching(Project project) {
 		return P2Client.Caching.defaultIfOfflineIs(project.getGradle().getStartParameter().isOffline());
 	}
 }

--- a/plugin-gradle/src/test/java/dev/equo/ide/gradle/EquoIdeTest.java
+++ b/plugin-gradle/src/test/java/dev/equo/ide/gradle/EquoIdeTest.java
@@ -112,7 +112,14 @@ public class EquoIdeTest extends GradleHarness {
 		Assertions.assertThat(build.getOutput())
 				.contains(
 						"> You must call `equoIde` directly, you cannot call a task which depends on `equoIde`.");
+	}
 
-		System.out.println("build = " + build.getOutput());
+	@Test
+	public void equoIdeNoRepositories() throws IOException {
+		setFile("build.gradle").toLines("plugins { id 'dev.equo.ide' }", "equoIde {", "  jdt()", "}");
+		var build =
+				gradleRunner().withArguments("equoIde", "--stacktrace").forwardOutput().buildAndFail();
+		Assertions.assertThat(build.getOutput())
+				.contains("`repositories { mavenCentral() }` or something similar to your `build.gradle`");
 	}
 }

--- a/plugin-gradle/src/test/java/dev/equo/ide/gradle/EquoIdeTest.java
+++ b/plugin-gradle/src/test/java/dev/equo/ide/gradle/EquoIdeTest.java
@@ -16,7 +16,7 @@ package dev.equo.ide.gradle;
 import au.com.origin.snapshots.Expect;
 import au.com.origin.snapshots.junit5.SnapshotExtension;
 import java.io.IOException;
-import org.junit.jupiter.api.Disabled;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -68,6 +68,7 @@ public class EquoIdeTest extends GradleHarness {
 		setFile("build.gradle")
 				.toLines(
 						"plugins { id 'dev.equo.ide' }",
+						"repositories { mavenCentral() }",
 						"equoIde {",
 						"  p2repo 'https://download.eclipse.org/eclipse/updates/4.26/'",
 						"  install 'org.eclipse.swt'",
@@ -81,6 +82,7 @@ public class EquoIdeTest extends GradleHarness {
 		setFile("build.gradle")
 				.toLines(
 						"plugins { id 'dev.equo.ide' }",
+						"repositories { mavenCentral() }",
 						"equoIde {",
 						"  p2repo 'https://download.eclipse.org/eclipse/updates/4.26/'",
 						"  install 'org.eclipse.swt'",
@@ -92,17 +94,25 @@ public class EquoIdeTest extends GradleHarness {
 	}
 
 	@Test
-	@Disabled
-	public void equoIde() throws IOException {
+	public void equoIdeWithDependency() throws IOException {
 		setFile("build.gradle")
 				.toLines(
 						"plugins { id 'dev.equo.ide' }",
 						"equoIde {",
+						"  jdt()",
 						"}",
-						"// (placeholder so GPJ formats this nicely)");
-		gradleRunner()
-				.withArguments("equoIde", "--show-console", "--stacktrace")
-				.forwardOutput()
-				.build();
+						"tasks.register('dependsOnEquo') {",
+						"  dependsOn 'equoIde'",
+						"}");
+		var build =
+				gradleRunner()
+						.withArguments("dependsOnEquo", "--stacktrace")
+						.forwardOutput()
+						.buildAndFail();
+		Assertions.assertThat(build.getOutput())
+				.contains(
+						"> You must call `equoIde` directly, you cannot call a task which depends on `equoIde`.");
+
+		System.out.println("build = " + build.getOutput());
 	}
 }


### PR DESCRIPTION
We can parse the command line to see if `equoIde` is going to run. If it isn't, then we don't need to add any dependencies to its configuration.

This means that CI builds don't need to download IDE dependencies.