### PR TITLE
Improve cache location for p2 data

### DIFF
--- a/solstice/CHANGELOG.md
+++ b/solstice/CHANGELOG.md
@@ -4,9 +4,9 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
 ### Fixed
-- Fail more loudly when the p2 client gets 502 errors.
+- Fail more loudly when the p2 client gets 502 errors. ([#130](https://github.com/equodev/equo-ide/pull/130))
 ### Changed
-- Changed the default location for all p2 data (metadata, bundle pool, queries, and nested jars) to be `~/.m2/repository/dev/equo/p2-data/`
+- Changed the default location for all p2 data (metadata, bundle pool, queries, and nested jars) to be `~/.m2/repository/dev/equo/p2-data/`. ([#131](https://github.com/equodev/equo-ide/pull/131))
   - If this location fails for some reason, it then tries `$GRADLE_USER_HOME/caches/p2-data`
   - This improves CI caching and follows user feedback ([spotless#1687](https://github.com/diffplug/spotless/issues/1687), )
 

--- a/solstice/CHANGELOG.md
+++ b/solstice/CHANGELOG.md
@@ -5,6 +5,10 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 ## [Unreleased]
 ### Fixed
 - Fail more loudly when the p2 client gets 502 errors.
+### Changed
+- Changed the default location for all p2 data (metadata, bundle pool, queries, and nested jars) to be `~/.m2/repository/dev/equo/p2-data/`
+  - If this location fails for some reason, it then tries `$GRADLE_USER_HOME/caches/p2-data`
+  - This improves CI caching and follows user feedback ([spotless#1687](https://github.com/diffplug/spotless/issues/1687), )
 
 ## [1.3.0] - 2023-05-17
 ### Added

--- a/solstice/src/main/java/dev/equo/solstice/NestedJars.java
+++ b/solstice/src/main/java/dev/equo/solstice/NestedJars.java
@@ -277,9 +277,9 @@ public abstract class NestedJars {
 
 	protected abstract List<URL> listNestedJars();
 
-	/** Extracts nested jars into {@link dev.equo.solstice.p2.CacheLocations#nestedJars()}. */
+	/** Extracts nested jars into {@link dev.equo.solstice.p2.CacheLocations#p2nestedJars()}. */
 	public List<Map.Entry<URL, File>> extractAllNestedJars() {
-		return extractAllNestedJars(CacheLocations.nestedJars());
+		return extractAllNestedJars(CacheLocations.p2nestedJars());
 	}
 
 	public List<Map.Entry<URL, File>> extractAllNestedJars(File nestedJarFolder) {

--- a/solstice/src/main/java/dev/equo/solstice/p2/CacheLocations.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/CacheLocations.java
@@ -14,64 +14,30 @@
 package dev.equo.solstice.p2;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Optional;
 
 /**
  * There are a few things which EquoIDE needs to cache on the developer's machine. They are
  * described exhaustively by this class.
  *
  * <ul>
- *   <li>{@link #p2metadata()}
- *   <li>{@link #p2bundlePool()}
- *   <li>{@link #ideWorkspaces()}
- *   <li>{@link #p2Queries()}
- *   <li>{@link #nestedJars()}
- * </ul>
- *
- * <p>All these values can be overridden by setting the value of the `public static
- * override_whatever` variable.
- *
- * <p>If you happen to be using Gradle, you can override these by setting any of the following in
- * your {@code ~/.gradle/gradle.properties} file.
- *
- * <ul>
- *   <li>{@code equo_override_p2metadata}
- *   <li>{@code equo_override_p2bundlePool}
- *   <li>{@code equo_override_ideWorkspaces}
- *   <li>{@code equo_override_p2Queries}
- *   <li>{@code equo_override_nestedJars}
+ *   <li>{@link #ideWorkspaces()} defaults to {@code ~/.equo/ide-workspaces}, can override with
+ *       {@link #override_ideWorkspaces}
+ *   <li>{@link #p2data()} defaults to {@code ~/.m2/repository/dev/equo/p2-data/}, can override with
+ *       {@link #override_p2data}
+ *       <ul>
+ *         <li>If we get any errors creating the default, it also tries {@code
+ *             GRADLE_USER_HOME/caches/p2-data}
+ *       </ul>
  * </ul>
  */
 public class CacheLocations {
 	private CacheLocations() {}
 
-	private static final String ROOT = ".equo";
-
-	/**
-	 * {@link P2Client} can use HTTP caching to speed up browsing of p2 metadata, and also to allow
-	 * offline p2 queries.
-	 *
-	 * <p>Rather than downloading this metadata over and over, we only download it once, and cache the
-	 * results here.
-	 */
-	public static File p2metadata() {
-		return defOverride(ROOT + "/p2-metadata", override_p2metadata);
+	private static Path userHome() {
+		return new File(System.getProperty("user.home")).toPath();
 	}
-
-	public static File override_p2metadata = null;
-
-	/**
-	 * Bundle pool used for caching jars and assembling disjoint eclipse installs:
-	 * `~/.equo/bundle-pool`
-	 *
-	 * <p>Oomph does this by default in the given location.
-	 */
-	public static File p2bundlePool() {
-		return defOverride(ROOT + "/p2-bundle-pool", override_p2bundlePool);
-	}
-
-	public static File override_p2bundlePool = null;
 
 	/**
 	 * When EquoIDE creates an IDE for you, it must also create an Eclipse workspace. Unfortunately,
@@ -81,33 +47,71 @@ public class CacheLocations {
 	 * <p>As a workaround, we put all eclipse workspaces in a central location, which is tied to their
 	 * project directory. Whenever a new workspace is created, we do a quick check to make sure there
 	 * aren't any stale workspaces. If the workspace has gone stale, we delete it.
+	 *
+	 * <p>Default value is {@code ~/.equo}, override by setting {@link #override_ideWorkspaces}.
 	 */
 	public static File ideWorkspaces() {
-		return defOverride(ROOT + "/ide-workspaces", override_ideWorkspaces);
+		if (ideWorkspaces == null) {
+			ideWorkspaces = override_ideWorkspaces;
+			if (ideWorkspaces == null) {
+				ideWorkspaces = userHome().resolve(".equo").resolve("ide-workspaces").toFile();
+			}
+		}
+		return ideWorkspaces;
 	}
 
+	private static File ideWorkspaces = null;
 	public static File override_ideWorkspaces = null;
 
-	/** Directory used to cache p2 queries: `~/.equo/p2-queries` */
-	public static File p2Queries() {
-		return defOverride(ROOT + "/p2-queries", override_p2Queries);
+	private static final String P2_DATA_WITHIN_M2 = "repository/dev/equo/p2-data/";
+	private static final String P2_DATA_GRADLE_USER_HOME = "caches/p2-data";
+
+	/**
+	 * Bundle pool used for caching jars and assembling disjoint eclipse installs:
+	 * `~/.equo/bundle-pool`
+	 *
+	 * <p>Oomph does this by default in the given location.
+	 */
+	public static File p2data() {
+		if (p2data == null) {
+			p2data = override_p2data;
+			if (p2data == null) {
+				try {
+					Path m2 = userHome().resolve(".m2");
+					if (!Files.exists(m2)) {
+						Files.createDirectories(m2);
+					}
+					Path p2Data = m2.resolve(P2_DATA_WITHIN_M2);
+					p2data = p2Data.resolve("repository/dev/equo/p2-data").toFile();
+				} catch (Exception e) {
+					var gradleUserHome = System.getenv("GRADLE_USER_HOME");
+					if (gradleUserHome == null) {
+						throw Unchecked.wrap(e);
+					} else {
+						p2data = new File(gradleUserHome).toPath().resolve(P2_DATA_GRADLE_USER_HOME).toFile();
+					}
+				}
+			}
+		}
+		return p2data;
 	}
 
-	public static File override_p2Queries = null;
+	private static File p2data = null;
+	public static File override_p2data = null;
 
-	/** Directory used to cache p2 queries: `~/.equo/nested-jars` */
-	public static File nestedJars() {
-		return defOverride(ROOT + "/nested-jars", override_nestedJars);
+	static File p2Queries() {
+		return new File(p2data(), "queries");
 	}
 
-	public static File override_nestedJars = null;
-
-	private static File defOverride(String userHomeRelative, File override) {
-		return Optional.ofNullable(override)
-				.orElseGet(() -> userHome().resolve(userHomeRelative).toFile());
+	static File p2metadata() {
+		return new File(p2data(), "metadata");
 	}
 
-	private static Path userHome() {
-		return new File(System.getProperty("user.home")).toPath();
+	static File p2bundlePool() {
+		return new File(p2data(), "bundle-pool");
+	}
+
+	public static File p2nestedJars() {
+		return new File(p2data(), "nested-jars");
 	}
 }


### PR DESCRIPTION
Following up on user feedback when this was incorporated into Spotless

- https://github.com/diffplug/spotless/pull/1524#issuecomment-1511427577
- https://github.com/diffplug/spotless/issues/1669#issuecomment-1500809098
- https://github.com/diffplug/spotless/issues/1687

The p2 data has moved from `~/.equo/xxx` to `~/.m2/repository/dev/equo/p2-data`. We also have a special case for when this fails but a `GRADLE_USER_HOME` is set, which is apparently the case for some CI setups.