### PR TITLE
Eclipse 4.28 (2023-06 SimRel)

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -65,10 +65,9 @@ This catalog is a useful reference for the p2 urls, code repositories, and issue
 - Code & issues https://github.com/eclipse-pde
 
 ### `egit`
-- Latest release https://download.eclipse.org/egit/updates-6.5/
+- Latest release https://download.eclipse.org/egit/updates-6.6/
 - Code https://git.eclipse.org/c/egit/egit.git/
 - Issues at [bugs.eclipse.org](https://bugs.eclipse.org/bugs/buglist.cgi?bug_file_loc_type=allwordssubstr&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&bugidtype=include&chfieldto=Now&classification=Technology&cmdtype=doit&emailtype1=exact&emailtype2=substring&field0-0-0=noop&keywords_type=allwords&long_desc_type=allwordssubstr&order=Reuse%20same%20sort%20as%20last%20time&product=EGit&query_format=advanced&short_desc_type=allwordssubstr&status_whiteboard_type=allwordssubstr&type0-0-0=noop)
-
 
 ## Build systems
 
@@ -80,11 +79,11 @@ This catalog is a useful reference for the p2 urls, code repositories, and issue
 
 ### `m2e`
 
-- Latest release https://download.eclipse.org/technology/m2e/releases/2.2.1/
+- Latest release https://download.eclipse.org/technology/m2e/releases/2.3.0/
 - Code & issues https://github.com/eclipse-m2e/m2e-core
 - Also a transitive dependency on some jars from
-  - https://download.eclipse.org/webtools/downloads/drops/R3.29.0/R-3.29.0-20230303230236/repository/
-  - https://download.eclipse.org/tools/orbit/downloads/drops/R20230302014618/repository/
+  - https://download.eclipse.org/webtools/downloads/drops/R3.30.0/R-3.30.0-20230603084739
+  - https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository/
 
 ## AI assistants
 
@@ -110,12 +109,12 @@ This catalog is a useful reference for the p2 urls, code repositories, and issue
 
 ### `cdt`
 
-- Latest release https://download.eclipse.org/tools/cdt/releases/11.1/cdt-11.1.0/
+- Latest release https://download.eclipse.org/tools/cdt/releases/11.2/cdt-11.2.0/
 - Code & issues https://github.com/eclipse-cdt
 
 ### `tmTerminal`
 
-- Latest release https://download.eclipse.org/tools/cdt/releases/11.1/cdt-11.1.0/
+- Latest release https://download.eclipse.org/tools/cdt/releases/11.2/cdt-11.2.0/
 - Code & issues https://github.com/eclipse-cdt
 
 ### `rust`

--- a/plugin-gradle/CHANGELOG.md
+++ b/plugin-gradle/CHANGELOG.md
@@ -7,6 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 - `tabnine()` (Copilot-style AI completion) to the plugin catalog. ([#136](https://github.com/equodev/equo-ide/pull/136))
 - `assistAI()` (ChatGPT) is now available in the EquoIDE plugin catalog. ([#134](https://github.com/equodev/equo-ide/pull/134))
 - `egit()` is now available in the EquoIDE plugin catalog. ([#133](https://github.com/equodev/equo-ide/pull/133))
+- Bump all defaults to Eclipse 4.28 (2023-06). ([#137](https://github.com/equodev/equo-ide/pull/137))
 ### Fixed
 - `branding()` no longer loads SWT classes at definition time, which required build plugins to have SWT on the classpath. ([#135](https://github.com/equodev/equo-ide/pull/135))
 

--- a/plugin-gradle/src/test/java/dev/equo/ide/gradle/GradleCatalogTest.java
+++ b/plugin-gradle/src/test/java/dev/equo/ide/gradle/GradleCatalogTest.java
@@ -36,7 +36,7 @@ public class GradleCatalogTest extends GradleHarness {
 	@Test
 	public void simple(Expect expect) throws IOException {
 		test("jdt('4.27')", expect.scenario("jdt"));
-		test("gradleBuildship()", expect.scenario("gradleBuildship"));
+		test("platform('4.27')\ngradleBuildship()", expect.scenario("gradleBuildship"));
 	}
 
 	@Test

--- a/plugin-gradle/src/test/java/dev/equo/ide/gradle/GradleCatalogTest.java
+++ b/plugin-gradle/src/test/java/dev/equo/ide/gradle/GradleCatalogTest.java
@@ -35,7 +35,7 @@ public class GradleCatalogTest extends GradleHarness {
 
 	@Test
 	public void simple(Expect expect) throws IOException {
-		test("jdt()", expect.scenario("jdt"));
+		test("jdt('4.27')", expect.scenario("jdt"));
 		test("gradleBuildship()", expect.scenario("gradleBuildship"));
 	}
 

--- a/plugin-gradle/src/test/java/dev/equo/ide/gradle/__snapshots__/GradleCatalogTest.snap
+++ b/plugin-gradle/src/test/java/dev/equo/ide/gradle/__snapshots__/GradleCatalogTest.snap
@@ -2,8 +2,8 @@ dev.equo.ide.gradle.GradleCatalogTest.simple[gradleBuildship]=[
 +-------------+----------------------------------------------------------------------------------------+
 | kind        | value                                                                                  |
 +-------------+----------------------------------------------------------------------------------------+
-| p2repo      | https://download.eclipse.org/buildship/updates/e423/releases/3.x/3.1.6.v20220511-1359/ |
-| p2repo      | https://download.eclipse.org/eclipse/updates/4.27/                                     |
+| p2repo      | https://download.eclipse.org/buildship/updates/e423/releases/3.x/3.1.7.v20230428-1420/ |
+| p2repo      | https://download.eclipse.org/eclipse/updates/4.28/                                     |
 | install     | org.eclipse.buildship.feature.group                                                    |
 | install     | org.eclipse.platform.ide.categoryIU                                                    |
 | install     | org.eclipse.releng.java.languages.categoryIU                                           |
@@ -19,7 +19,7 @@ dev.equo.ide.gradle.GradleCatalogTest.simple[jdt]=[
 +-------------+----------------------------------------------------+
 | kind        | value                                              |
 +-------------+----------------------------------------------------+
-| p2repo      | https://download.eclipse.org/eclipse/updates/4.27/ |
+| p2repo      | https://download.eclipse.org/eclipse/updates/4.28/ |
 | install     | org.eclipse.platform.ide.categoryIU                |
 | install     | org.eclipse.releng.java.languages.categoryIU       |
 | filter      | platform-neutral                                   |

--- a/plugin-gradle/src/test/java/dev/equo/ide/gradle/__snapshots__/GradleCatalogTest.snap
+++ b/plugin-gradle/src/test/java/dev/equo/ide/gradle/__snapshots__/GradleCatalogTest.snap
@@ -19,7 +19,7 @@ dev.equo.ide.gradle.GradleCatalogTest.simple[jdt]=[
 +-------------+----------------------------------------------------+
 | kind        | value                                              |
 +-------------+----------------------------------------------------+
-| p2repo      | https://download.eclipse.org/eclipse/updates/4.28/ |
+| p2repo      | https://download.eclipse.org/eclipse/updates/4.27/ |
 | install     | org.eclipse.platform.ide.categoryIU                |
 | install     | org.eclipse.releng.java.languages.categoryIU       |
 | filter      | platform-neutral                                   |

--- a/plugin-gradle/src/test/java/dev/equo/ide/gradle/__snapshots__/GradleCatalogTest.snap
+++ b/plugin-gradle/src/test/java/dev/equo/ide/gradle/__snapshots__/GradleCatalogTest.snap
@@ -3,7 +3,7 @@ dev.equo.ide.gradle.GradleCatalogTest.simple[gradleBuildship]=[
 | kind        | value                                                                                  |
 +-------------+----------------------------------------------------------------------------------------+
 | p2repo      | https://download.eclipse.org/buildship/updates/e423/releases/3.x/3.1.7.v20230428-1420/ |
-| p2repo      | https://download.eclipse.org/eclipse/updates/4.28/                                     |
+| p2repo      | https://download.eclipse.org/eclipse/updates/4.27/                                     |
 | install     | org.eclipse.buildship.feature.group                                                    |
 | install     | org.eclipse.platform.ide.categoryIU                                                    |
 | install     | org.eclipse.releng.java.languages.categoryIU                                           |

--- a/plugin-maven/CHANGELOG.md
+++ b/plugin-maven/CHANGELOG.md
@@ -7,6 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 - `<tabnine/>` (Copilot-style AI completion) to the plugin catalog. ([#136](https://github.com/equodev/equo-ide/pull/136))
 - `<assistAI/>` (a ChatGPT plugin) is now available in the EquoIDE plugin catalog. ([#134](https://github.com/equodev/equo-ide/pull/134))
 - `<egit/>` is now available in the EquoIDE plugin catalog. ([#133](https://github.com/equodev/equo-ide/pull/133))
+- Bump all defaults to Eclipse 4.28 (2023-06). ([#137](https://github.com/equodev/equo-ide/pull/137))
 ### Fixed
 - `<branding>` no longer loads SWT classes at definition time, which required build plugins to have SWT on the classpath. ([#135](https://github.com/equodev/equo-ide/pull/135))
 

--- a/plugin-maven/src/test/java/dev/equo/ide/maven/MavenCatalogTest.java
+++ b/plugin-maven/src/test/java/dev/equo/ide/maven/MavenCatalogTest.java
@@ -35,8 +35,10 @@ public class MavenCatalogTest extends MavenHarness {
 
 	@Test
 	public void simple(Expect expect) throws Exception {
-		test("<jdt/>", expect.scenario("jdt"));
-		test("<gradleBuildship/>", expect.scenario("gradleBuildship"));
+		test("<platform><version>4.27</version></platform><jdt/>", expect.scenario("jdt"));
+		test(
+				"<platform><version>4.27</version></platform><gradleBuildship/>",
+				expect.scenario("gradleBuildship"));
 	}
 
 	@Test

--- a/plugin-maven/src/test/java/dev/equo/ide/maven/__snapshots__/MavenCatalogTest.snap
+++ b/plugin-maven/src/test/java/dev/equo/ide/maven/__snapshots__/MavenCatalogTest.snap
@@ -3,7 +3,7 @@ dev.equo.ide.maven.MavenCatalogTest.simple[gradleBuildship]=[
 | kind        | value                                                                                  |
 +-------------+----------------------------------------------------------------------------------------+
 | p2repo      | https://download.eclipse.org/buildship/updates/e423/releases/3.x/3.1.7.v20230428-1420/ |
-| p2repo      | https://download.eclipse.org/eclipse/updates/4.28/                                     |
+| p2repo      | https://download.eclipse.org/eclipse/updates/4.27/                                     |
 | install     | org.eclipse.buildship.feature.group                                                    |
 | install     | org.eclipse.platform.ide.categoryIU                                                    |
 | install     | org.eclipse.releng.java.languages.categoryIU                                           |
@@ -21,7 +21,7 @@ dev.equo.ide.maven.MavenCatalogTest.simple[jdt]=[
 +-------------+----------------------------------------------------+
 | kind        | value                                              |
 +-------------+----------------------------------------------------+
-| p2repo      | https://download.eclipse.org/eclipse/updates/4.28/ |
+| p2repo      | https://download.eclipse.org/eclipse/updates/4.27/ |
 | install     | org.eclipse.platform.ide.categoryIU                |
 | install     | org.eclipse.releng.java.languages.categoryIU       |
 | filter      | maven-filter-unnamed--1003173200                   |

--- a/plugin-maven/src/test/java/dev/equo/ide/maven/__snapshots__/MavenCatalogTest.snap
+++ b/plugin-maven/src/test/java/dev/equo/ide/maven/__snapshots__/MavenCatalogTest.snap
@@ -2,8 +2,8 @@ dev.equo.ide.maven.MavenCatalogTest.simple[gradleBuildship]=[
 +-------------+----------------------------------------------------------------------------------------+
 | kind        | value                                                                                  |
 +-------------+----------------------------------------------------------------------------------------+
-| p2repo      | https://download.eclipse.org/buildship/updates/e423/releases/3.x/3.1.6.v20220511-1359/ |
-| p2repo      | https://download.eclipse.org/eclipse/updates/4.27/                                     |
+| p2repo      | https://download.eclipse.org/buildship/updates/e423/releases/3.x/3.1.7.v20230428-1420/ |
+| p2repo      | https://download.eclipse.org/eclipse/updates/4.28/                                     |
 | install     | org.eclipse.buildship.feature.group                                                    |
 | install     | org.eclipse.platform.ide.categoryIU                                                    |
 | install     | org.eclipse.releng.java.languages.categoryIU                                           |
@@ -21,7 +21,7 @@ dev.equo.ide.maven.MavenCatalogTest.simple[jdt]=[
 +-------------+----------------------------------------------------+
 | kind        | value                                              |
 +-------------+----------------------------------------------------+
-| p2repo      | https://download.eclipse.org/eclipse/updates/4.27/ |
+| p2repo      | https://download.eclipse.org/eclipse/updates/4.28/ |
 | install     | org.eclipse.platform.ide.categoryIU                |
 | install     | org.eclipse.releng.java.languages.categoryIU       |
 | filter      | maven-filter-unnamed--1003173200                   |

--- a/solstice/CHANGELOG.md
+++ b/solstice/CHANGELOG.md
@@ -7,6 +7,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 - Tabnine (Copilot-style AI completion) to the plugin catalog. ([#136](https://github.com/equodev/equo-ide/pull/136))
 - AssistAI (ChatGPT) to the plugin catalog. ([#134](https://github.com/equodev/equo-ide/pull/134))
 - EGit to the plugin catalog. ([#133](https://github.com/equodev/equo-ide/pull/133))
+- Bump all defaults to Eclipse 4.28 (2023-06) and handle slf4j 2.x. ([#137](https://github.com/equodev/equo-ide/pull/137))
 ### Fixed
 - OSGi services implemented by inner classes (e.g. `SomeClass$InnerClass`) are now instantiated correctly.
 - `IdeHookBranding` no longer loads SWT classes at definition time, which required build plugins to have SWT on the classpath. ([#135](https://github.com/equodev/equo-ide/pull/135))

--- a/solstice/src/main/java/dev/equo/ide/Catalog.java
+++ b/solstice/src/main/java/dev/equo/ide/Catalog.java
@@ -302,7 +302,7 @@ public class Catalog implements Comparable<Catalog> {
 										+ catalog.name
 										+ " "
 										+ entry.getValue()
-										+ " which requires JRE "
+										+ " which is the latest version for JRE "
 										+ entry.getKey()
 										+ ". There is a newer version available, "
 										+ catalog.name

--- a/solstice/src/main/java/dev/equo/ide/Catalog.java
+++ b/solstice/src/main/java/dev/equo/ide/Catalog.java
@@ -49,7 +49,7 @@ public class Catalog implements Comparable<Catalog> {
 			new Catalog(
 					"egit",
 					"https://download.eclipse.org/egit/updates-" + V + "/",
-					jre11("6.5"),
+					jre11("6.6"),
 					List.of("org.eclipse.egit.feature.group"));
 
 	/** Pure transitive of m2e and AssistAI. */
@@ -57,7 +57,7 @@ public class Catalog implements Comparable<Catalog> {
 			new Catalog(
 					"orbit",
 					"https://download.eclipse.org/tools/orbit/downloads/drops/" + V + "/repository/",
-					jre11("R20230302014618"),
+					jre11("R20230531010532"),
 					List.of());
 
 	public static final CatalogAssistAI ASSIST_AI = new CatalogAssistAI();
@@ -73,7 +73,7 @@ public class Catalog implements Comparable<Catalog> {
 			new Catalog(
 					"gradleBuildship",
 					"https://download.eclipse.org/buildship/updates/e423/releases/3.x/" + V,
-					jre11("3.1.6.v20220511-1359"),
+					jre11("3.1.7.v20230428-1420"),
 					List.of("org.eclipse.buildship.feature.group"),
 					JDT);
 
@@ -82,14 +82,14 @@ public class Catalog implements Comparable<Catalog> {
 			new Catalog(
 					"wst",
 					"https://download.eclipse.org/webtools/downloads/drops/" + V + "/repository/",
-					jre11("R3.29.0/R-3.29.0-20230303230236"),
+					jre11("R3.30.0/R-3.30.0-20230603084739"),
 					List.of());
 
 	public static final Catalog M2E =
 			new Catalog(
 					"m2e",
 					"https://download.eclipse.org/technology/m2e/releases/" + V,
-					jre11("1.20.1").jre(17, "2.2.1"),
+					jre11("1.20.1").jre(17, "2.3.0"),
 					List.of("org.eclipse.m2e.feature.feature.group"),
 					JDT,
 					WST,
@@ -120,7 +120,7 @@ public class Catalog implements Comparable<Catalog> {
 			new Catalog(
 					"tmTerminal",
 					"https://download.eclipse.org/tools/cdt/releases/" + V,
-					jre11("11.1/cdt-11.1.0"),
+					jre11("11.2/cdt-11.2.0"),
 					List.of(
 							"org.eclipse.tm.terminal.feature.feature.group",
 							"org.eclipse.tm.terminal.view.feature.feature.group"),

--- a/solstice/src/main/java/dev/equo/ide/CatalogPlatform.java
+++ b/solstice/src/main/java/dev/equo/ide/CatalogPlatform.java
@@ -20,7 +20,7 @@ public class CatalogPlatform extends Catalog {
 		super(
 				"platform",
 				"https://download.eclipse.org/eclipse/updates/" + V,
-				jre11("4.28"),
+				jre11("4.27").jre(17, "4.28"),
 				List.of("org.eclipse.platform.ide.categoryIU"));
 	}
 

--- a/solstice/src/main/java/dev/equo/ide/CatalogPlatform.java
+++ b/solstice/src/main/java/dev/equo/ide/CatalogPlatform.java
@@ -20,7 +20,7 @@ public class CatalogPlatform extends Catalog {
 		super(
 				"platform",
 				"https://download.eclipse.org/eclipse/updates/" + V,
-				jre11("4.27"),
+				jre11("4.28"),
 				List.of("org.eclipse.platform.ide.categoryIU"));
 	}
 

--- a/solstice/src/main/java/dev/equo/solstice/NestedJars.java
+++ b/solstice/src/main/java/dev/equo/solstice/NestedJars.java
@@ -76,6 +76,7 @@ public abstract class NestedJars {
 			boolean useAtomos, CoordFormat format, P2QueryResult query) {
 		boolean needsApi = true;
 		boolean needsSimple = true;
+		boolean slf4j_is_2 = false;
 		if (query != null) {
 			query.getJarsOnMavenCentral().stream();
 			query.getJarsNotOnMavenCentral().stream().map(File::getName);
@@ -92,6 +93,7 @@ public abstract class NestedJars {
 				if (name.contains("slf4j")) {
 					if (name.contains("slf4j-api") || name.contains("slf4j.api")) {
 						needsApi = false;
+						slf4j_is_2 = name.contains("slf4j.api_2.") || name.contains("slf4j-api_2.");
 					} else {
 						needsSimple = false;
 					}
@@ -101,7 +103,7 @@ public abstract class NestedJars {
 			}
 		}
 		var coords = new ArrayList<String>();
-		String VER_SLF4J = "1.7.36";
+		String VER_SLF4J = slf4j_is_2 ? "2.0.7" : "1.7.36";
 		if (needsApi) {
 			coords.add(format.format("org.slf4j", "slf4j-api", VER_SLF4J, null));
 		}


### PR DESCRIPTION
Bump default catalog versions to Eclipse 4.28 (2023-06 SimRel).

Eclipse 4.28 now uses slf4j 2.x instead of 1.x - Equo picks which slf4j artifacts to put on the classpath based on which version of Eclipse platform you are using.