### PR TITLE
Fix Chromium browser

### DIFF
--- a/plugin-gradle/CHANGELOG.md
+++ b/plugin-gradle/CHANGELOG.md
@@ -3,7 +3,10 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
-
+### Fixed
+- Fix issues in Chromium browser. ([#141](https://github.com/equodev/equo-ide/pull/141))
+  - Now can calls multiple times setUrl.
+  - Welcome view and javadocs they look correct.
 ## [1.4.0] - 2023-06-16
 ### Added
 - `tabnine()` (Copilot-style AI completion) to the plugin catalog. ([#136](https://github.com/equodev/equo-ide/pull/136))

--- a/plugin-maven/CHANGELOG.md
+++ b/plugin-maven/CHANGELOG.md
@@ -3,7 +3,10 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
-
+### Fixed
+- Fix issues in Chromium browser. ([#141](https://github.com/equodev/equo-ide/pull/141))
+  - Now can calls multiple times setUrl.
+  - Welcome view and javadocs they look correct.
 ## [1.3.0] - 2023-06-16
 ### Added
 - `<tabnine/>` (Copilot-style AI completion) to the plugin catalog. ([#136](https://github.com/equodev/equo-ide/pull/136))

--- a/solstice/CHANGELOG.md
+++ b/solstice/CHANGELOG.md
@@ -3,7 +3,10 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
-
+### Fixed
+- Fix issues in Chromium browser. ([#141](https://github.com/equodev/equo-ide/pull/141))
+  - Now can calls multiple times setUrl.
+  - Welcome view and javadocs they look correct.
 ## [1.4.0] - 2023-06-16
 ### Added
 - Tabnine (Copilot-style AI completion) to the plugin catalog. ([#136](https://github.com/equodev/equo-ide/pull/136))

--- a/solstice/src/main/java/dev/equo/ide/BuildPluginIdeMain.java
+++ b/solstice/src/main/java/dev/equo/ide/BuildPluginIdeMain.java
@@ -101,6 +101,8 @@ public class BuildPluginIdeMain {
 			if (EquoChromium.isEnabled(ideHooks)) {
 				// This property is used to fix the error in the setUrl method.
 				vmArgs.add("-Dchromium.args=--disable-site-isolation-trials");
+				// This property improve loading time of setText for large resources.
+				vmArgs.add("-Dchromium.setTextAsUrl=file:");
 				Patch.patch(classpathSorted, nestedJarFolder, "patch-chromium-swt");
 				SignedJars.stripIf(classpathSorted, fileName -> fileName.startsWith("org.eclipse.swt."));
 				vmArgs.add(

--- a/solstice/src/main/java/dev/equo/ide/BuildPluginIdeMain.java
+++ b/solstice/src/main/java/dev/equo/ide/BuildPluginIdeMain.java
@@ -99,6 +99,8 @@ public class BuildPluginIdeMain {
 			}
 			var vmArgs = new ArrayList<String>();
 			if (EquoChromium.isEnabled(ideHooks)) {
+				// This property is used to fix the error in the setUrl method.
+				vmArgs.add("-Dchromium.args=--disable-site-isolation-trials");
 				Patch.patch(classpathSorted, nestedJarFolder, "patch-chromium-swt");
 				SignedJars.stripIf(classpathSorted, fileName -> fileName.startsWith("org.eclipse.swt."));
 				vmArgs.add(


### PR DESCRIPTION
Added 2 properties that solve 2 encountered problems:

"-Dchromium.args=--disable-site-isolation-trials" resolves an issue that occurred when making a setUrl call in the Chromium browser; only the first call works.

The other property, "-Dchromium.setTextAsUrl=file:", resolves the loading time issues when performing a setText while using the Chromium browser. For example, in welcome views or javadocs.