### PR TITLE
Replace `useChromium` with `equoChromium`

### DIFF
--- a/plugin-gradle/CHANGELOG.md
+++ b/plugin-gradle/CHANGELOG.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
+### Changed
+- `useChromium` deprecated in favor of `equoChromium` which is now a standard catalog entry. ([#145](https://github.com/equodev/equo-ide/pull/145))
 
 ## [1.5.0] - 2023-06-22
 ### Added

--- a/plugin-gradle/README.md
+++ b/plugin-gradle/README.md
@@ -56,7 +56,7 @@ By default, SWT uses the system browser (Internet Explorer on Windows, Safari on
 
 ```gradle
 equoIde {
-  useChromium()
+  equoChromium()
 ```
 
 Using Equo Chromium will add `https://dl.equo.dev/chromium-swt-ee/equo-gpl/mvn` to your list of maven repositories, which is used only for the Chromium dependency.

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeExtension.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeExtension.java
@@ -14,7 +14,6 @@
 package dev.equo.ide.gradle;
 
 import dev.equo.ide.Catalog;
-import dev.equo.ide.EquoChromium;
 import dev.equo.ide.IdeHook;
 import dev.equo.ide.IdeHookBranding;
 import dev.equo.ide.IdeHookReflected;
@@ -38,7 +37,7 @@ public class EquoIdeExtension extends P2ModelDslWithCatalog {
 	}
 
 	public void useChromium() {
-		ideHooks.add(new EquoChromium());
+		super.equoChromium();
 	}
 
 	public IdeHookBranding branding() {

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeExtension.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeExtension.java
@@ -36,7 +36,9 @@ public class EquoIdeExtension extends P2ModelDslWithCatalog {
 		ideHooks.add(branding);
 	}
 
+	@Deprecated
 	public void useChromium() {
+		project.getLogger().warn("useChromium() is deprecated, use equoChromium() instead");
 		super.equoChromium();
 	}
 

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/EquoIdeGradlePlugin.java
@@ -126,13 +126,8 @@ public class EquoIdeGradlePlugin implements Plugin<Project> {
 									(ModuleDependency) project.getDependencies().add(EQUO_IDE, coordinate);
 							dep.setTransitive(false);
 						}
-						if (EquoChromium.isEnabled(extension.getIdeHooks())) {
+						if (EquoChromium.isEnabled(model)) {
 							project.getRepositories().maven((a) -> a.setUrl(EquoChromium.mavenRepo()));
-							for (var coordinate : EquoChromium.mavenCoordinates()) {
-								ModuleDependency dep =
-										(ModuleDependency) project.getDependencies().add(EQUO_IDE, coordinate);
-								dep.setTransitive(false);
-							}
 						}
 						equoIdeTask.configure(
 								task -> {

--- a/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2ModelDslWithCatalog.java
+++ b/plugin-gradle/src/main/java/dev/equo/ide/gradle/P2ModelDslWithCatalog.java
@@ -153,6 +153,20 @@ public class P2ModelDslWithCatalog extends P2ModelDsl {
 		return egit(null);
 	}
 
+	static class EquoChromium extends GradleCatalogDsl {
+		public EquoChromium(String urlOverride) {
+			super(Catalog.EQUO_CHROMIUM, urlOverride);
+		}
+	}
+
+	public EquoChromium equoChromium(String urlOverride) {
+		return add(new EquoChromium(urlOverride));
+	}
+
+	public EquoChromium equoChromium() {
+		return equoChromium(null);
+	}
+
 	public static class AssistAI extends GradleCatalogDsl {
 		public AssistAI(String urlOverride, Project project) {
 			super(Catalog.ASSIST_AI, urlOverride);

--- a/plugin-maven/CHANGELOG.md
+++ b/plugin-maven/CHANGELOG.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
+### Changed
+- `<useChromium>true</useChromium>` deprecated in favor of `<equoChromium/>` which is now a standard catalog entry. ([#145](https://github.com/equodev/equo-ide/pull/145))
 
 ## [1.3.1] - 2023-06-22
 ### Fixed

--- a/plugin-maven/CHANGELOG.md
+++ b/plugin-maven/CHANGELOG.md
@@ -5,6 +5,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 ## [Unreleased]
 ### Changed
 - `<useChromium>true</useChromium>` deprecated in favor of `<equoChromium/>` which is now a standard catalog entry. ([#145](https://github.com/equodev/equo-ide/pull/145))
+### Fixed
+- `egit`, `assistAI`, and `tabnine` were not hooked into the plugin catalog correctly, but they are now. ([#145](https://github.com/equodev/equo-ide/pull/145))
 
 ## [1.3.1] - 2023-06-22
 ### Fixed

--- a/plugin-maven/README.md
+++ b/plugin-maven/README.md
@@ -73,7 +73,7 @@ By default, SWT uses the system browser (Internet Explorer on Windows, Safari on
 
 ```xml
 <configuration>
-  <useChromium>true</useChromium>
+  <equoChromium/>
 ```
 
 Using Equo Chromium will add `https://dl.equo.dev/chromium-swt-ee/equo-gpl/mvn` to your list of maven repositories, which is used only for the Chromium dependency.

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/AbstractP2MojoWithCatalog.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/AbstractP2MojoWithCatalog.java
@@ -116,6 +116,14 @@ public abstract class AbstractP2MojoWithCatalog extends AbstractP2Mojo {
 		}
 	}
 
+	@Parameter EquoChromium equoChromium;
+
+	public static class EquoChromium extends MavenCatalogDsl {
+		public EquoChromium() {
+			super(Catalog.EQUO_CHROMIUM);
+		}
+	}
+
 	@Parameter private AssistAI assistAI;
 
 	public static class AssistAI extends MavenCatalogDsl {
@@ -242,7 +250,21 @@ public abstract class AbstractP2MojoWithCatalog extends AbstractP2Mojo {
 				new CatalogDsl.TransitiveAwareList<>();
 		// NB: each entry must be after all of its transitive dependencies
 		// e.g. jdt must be after platform
-		Stream.of(platform, jdt, gradleBuildship, pde, m2e, kotlin, tmTerminal, cdt, rust, groovy)
+		Stream.of(
+						platform,
+						jdt,
+						gradleBuildship,
+						pde,
+						egit,
+						equoChromium,
+						assistAI,
+						tabnine,
+						m2e,
+						kotlin,
+						tmTerminal,
+						cdt,
+						rust,
+						groovy)
 				.filter(Objects::nonNull)
 				.forEach(
 						dsl -> {

--- a/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
+++ b/plugin-maven/src/main/java/dev/equo/ide/maven/LaunchMojo.java
@@ -63,8 +63,13 @@ public class LaunchMojo extends AbstractP2MojoWithCatalog {
 	@Parameter(property = "showConsole", defaultValue = "false")
 	private boolean showConsole;
 
-	/** Replaces the standard SWT browser with Equo Chromium. */
+	/**
+	 * Replaces the standard SWT browser with Equo Chromium.
+	 *
+	 * @deprecated use equoChromium instead
+	 */
 	@Parameter(property = "useChromium", defaultValue = "false")
+	@Deprecated
 	private boolean useChromium;
 
 	/** Dumps the classpath (in order) without starting the application. */
@@ -101,6 +106,7 @@ public class LaunchMojo extends AbstractP2MojoWithCatalog {
 	public void execute() throws MojoExecutionException, MojoFailureException {
 		try {
 			if (useChromium) {
+				getLog().warn("<useChromium>true</useChromium> is deprecated, use <equoChromium/> instead");
 				if (equoChromium == null) {
 					equoChromium = new EquoChromium();
 				}

--- a/plugin-maven/src/test/java/dev/equo/ide/maven/__snapshots__/LaunchTest.snap
+++ b/plugin-maven/src/test/java/dev/equo/ide/maven/__snapshots__/LaunchTest.snap
@@ -30,6 +30,9 @@ equo-ide:launch
     egit
       (no description available)
 
+    equoChromium
+      (no description available)
+
     filters
       (no description available)
 
@@ -85,6 +88,7 @@ equo-ide:launch
     useChromium (Default: false)
       User property: useChromium
       Replaces the standard SWT browser with Equo Chromium.
+      Deprecated. use equoChromium instead
 
     welcome
       (no description available)

--- a/plugin-maven/src/test/java/dev/equo/ide/maven/__snapshots__/ListTest.snap
+++ b/plugin-maven/src/test/java/dev/equo/ide/maven/__snapshots__/ListTest.snap
@@ -360,6 +360,9 @@ equo-ide:list
     egit
       (no description available)
 
+    equoChromium
+      (no description available)
+
     filters
       (no description available)
 

--- a/solstice/CHANGELOG.md
+++ b/solstice/CHANGELOG.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
+### Changed
+- `EquoChromium` is now a standard catalog entry instead of a special-cased sentinel `IdeHook`. ([#145](https://github.com/equodev/equo-ide/pull/145))
 
 ## [1.5.0] - 2023-06-22
 ### Added

--- a/solstice/src/main/java/dev/equo/ide/BuildPluginIdeMain.java
+++ b/solstice/src/main/java/dev/equo/ide/BuildPluginIdeMain.java
@@ -98,7 +98,7 @@ public class BuildPluginIdeMain {
 				classpathSorted.add(nested.getValue());
 			}
 			var vmArgs = new ArrayList<String>();
-			if (EquoChromium.isEnabled(ideHooks)) {
+			if (EquoChromium.isEnabled(classpath)) {
 				// This property is used to fix the error in the setUrl method.
 				vmArgs.add("-Dchromium.args=--disable-site-isolation-trials");
 				// This property improve loading time of setText for large resources.

--- a/solstice/src/main/java/dev/equo/ide/Catalog.java
+++ b/solstice/src/main/java/dev/equo/ide/Catalog.java
@@ -179,9 +179,15 @@ public class Catalog implements Comparable<Catalog> {
 							),
 					PLATFORM);
 
+	public static final EquoChromium EQUO_CHROMIUM = new EquoChromium();
+
 	public static final Catalog CHATGPT =
 			new Catalog.PureMaven(
-					"chatGPT", jre11("0.1.0"), List.of("dev.equo.ide:equo-ide-chatgpt:" + V), PLATFORM);
+					"chatGPT",
+					jre11("0.1.0"),
+					List.of("dev.equo.ide:equo-ide-chatgpt:" + V),
+					PLATFORM,
+					EQUO_CHROMIUM);
 
 	private final String name;
 	private final String p2urlTemplate;

--- a/solstice/src/main/java/dev/equo/ide/EquoChromium.java
+++ b/solstice/src/main/java/dev/equo/ide/EquoChromium.java
@@ -14,30 +14,36 @@
 package dev.equo.ide;
 
 import com.diffplug.common.swt.os.SwtPlatform;
+import dev.equo.solstice.p2.P2Model;
+import java.io.File;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Utilities for setting up EquoChromium as the default browser implementation in the EquoIDE build
  * plugins.
  */
-public class EquoChromium implements IdeHook {
+public class EquoChromium extends Catalog.PureMaven {
+	EquoChromium() {
+		super(
+				"equoChromium",
+				jre11("106.0.3"),
+				List.of(
+						"com.equo:com.equo.chromium:" + V,
+						"com.equo:com.equo.chromium.cef." + SwtPlatform.getRunning() + ":" + V),
+				PLATFORM);
+	}
+
 	public static String mavenRepo() {
 		return "https://dl.equo.dev/chromium-swt-ee/equo-gpl/mvn";
 	}
 
-	public static java.util.List<String> mavenCoordinates() {
-		return java.util.List.of(
-				"com.equo:com.equo.chromium:106.0.3",
-				"com.equo:com.equo.chromium.cef." + SwtPlatform.getRunning() + ":106.0.3");
+	public static boolean isEnabled(Collection<File> classpath) {
+		return classpath.stream().anyMatch(file -> file.getName().startsWith("com.equo.chromium"));
 	}
 
-	public static boolean isEnabled(IdeHook.List hooks) {
-		return hooks.stream().anyMatch(hook -> hook instanceof EquoChromium);
+	public static boolean isEnabled(P2Model model) {
+		return model.getPureMaven().stream()
+				.anyMatch(coord -> coord.startsWith("com.equo:com.equo.chromium:"));
 	}
-
-	@Override
-	public IdeHookInstantiated instantiate() throws Exception {
-		return new Instantiated();
-	}
-
-	class Instantiated implements IdeHookInstantiated {}
 }


### PR DESCRIPTION
@agustinschilling Just wanted to let you know about this PR since it changes some stuff from your original PR

- #123 

From a user perspective the only change is that it deprecates `useChromium` to replace with `equoChromium` (which is the name you originally proposed in your PR).

From a dev perspective, the big change from an earlier PR is that the plugin catalog can now handle pure-maven plugins, not only p2 plugins. So instead of `EquoChromium` being a "magic value" implementation of `IdeHook`, it can be a plain catalog entry.

The point of this change is that now `equoChromium` can be a dependency in the catalog entries. For example, `pde` requires `jdt`. We are about to launch a [ChatGPT](https://github.com/equodev/equo-ide-chatgpt) plugin in the catalog, and now it can use `equoChromium` as a catalog dependency. There's also less special-casing.
