### PR TITLE
Add Wayland support when using the equoChromium browser

### DIFF
--- a/plugin-gradle/CHANGELOG.md
+++ b/plugin-gradle/CHANGELOG.md
@@ -3,7 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
-
+### Fixed
+- equoChromium browser now works correctly with wayland. ([#150](https://github.com/equodev/equo-ide/pull/150))
 ## [1.6.0] - 2023-06-25
 ### Added
 - `chatGPT()`, our [first Eclipse plugin](https://github.com/equodev/equo-ide-chatgpt) built and distributed without OSGi or p2, was added to the plugin catalog. ([#144](https://github.com/equodev/equo-ide/pull/144))

--- a/plugin-gradle/CHANGELOG.md
+++ b/plugin-gradle/CHANGELOG.md
@@ -4,7 +4,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
 ### Fixed
-- equoChromium browser now works correctly with wayland. ([#150](https://github.com/equodev/equo-ide/pull/150))
+- `equoChromium` browser now works correctly with Linux wayland. ([#150](https://github.com/equodev/equo-ide/pull/150))
+
 ## [1.6.0] - 2023-06-25
 ### Added
 - `chatGPT()`, our [first Eclipse plugin](https://github.com/equodev/equo-ide-chatgpt) built and distributed without OSGi or p2, was added to the plugin catalog. ([#144](https://github.com/equodev/equo-ide/pull/144))

--- a/plugin-maven/CHANGELOG.md
+++ b/plugin-maven/CHANGELOG.md
@@ -4,7 +4,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
 ### Fixed
-- equoChromium browser now works correctly with wayland. ([#150](https://github.com/equodev/equo-ide/pull/150))
+- `equoChromium` browser now works correctly with Linux wayland. ([#150](https://github.com/equodev/equo-ide/pull/150))
+
 ## [1.4.0] - 2023-06-25
 ### Added
 - `<chatGPT/>`, our [first Eclipse plugin](https://github.com/equodev/equo-ide-chatgpt) built and distributed without OSGi or p2, was added to the plugin catalog. ([#144](https://github.com/equodev/equo-ide/pull/144))

--- a/plugin-maven/CHANGELOG.md
+++ b/plugin-maven/CHANGELOG.md
@@ -3,7 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
-
+### Fixed
+- equoChromium browser now works correctly with wayland. ([#150](https://github.com/equodev/equo-ide/pull/150))
 ## [1.4.0] - 2023-06-25
 ### Added
 - `<chatGPT/>`, our [first Eclipse plugin](https://github.com/equodev/equo-ide-chatgpt) built and distributed without OSGi or p2, was added to the plugin catalog. ([#144](https://github.com/equodev/equo-ide/pull/144))

--- a/solstice/CHANGELOG.md
+++ b/solstice/CHANGELOG.md
@@ -3,7 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
-
+### Fixed
+- equoChromium browser now works correctly with wayland. ([#150](https://github.com/equodev/equo-ide/pull/150))
 ## [1.6.0] - 2023-06-25
 ### Added
 - Our own [ChatGPT plugin](https://github.com/equodev/equo-ide-chatgpt) was added to the plugin catalog. ([#144](https://github.com/equodev/equo-ide/pull/144))

--- a/solstice/CHANGELOG.md
+++ b/solstice/CHANGELOG.md
@@ -4,7 +4,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
 ### Fixed
-- equoChromium browser now works correctly with wayland. ([#150](https://github.com/equodev/equo-ide/pull/150))
+- `equoChromium` browser now works correctly with Linux wayland. ([#150](https://github.com/equodev/equo-ide/pull/150))
+
 ## [1.6.0] - 2023-06-25
 ### Added
 - Our own [ChatGPT plugin](https://github.com/equodev/equo-ide-chatgpt) was added to the plugin catalog. ([#144](https://github.com/equodev/equo-ide/pull/144))

--- a/solstice/src/main/java/dev/equo/ide/BuildPluginIdeMain.java
+++ b/solstice/src/main/java/dev/equo/ide/BuildPluginIdeMain.java
@@ -98,11 +98,18 @@ public class BuildPluginIdeMain {
 				classpathSorted.add(nested.getValue());
 			}
 			var vmArgs = new ArrayList<String>();
+			var environmentVars = new LinkedHashMap<String, String>();
 			if (Catalog.EQUO_CHROMIUM.isEnabled(classpath)) {
 				// This property is used to fix the error in the setUrl method.
 				vmArgs.add("-Dchromium.args=--disable-site-isolation-trials");
 				// This property improve loading time of setText for large resources.
 				vmArgs.add("-Dchromium.setTextAsUrl=file:");
+				// Fix graphics on linux
+				if (OS.getRunning().isLinux()) {
+					environmentVars.put("GDK_BACKEND", "x11");
+				}
+				// Patch in our browser replacement, which requires stripping the signature from the SWT
+				// packages, and activate the license
 				Patch.patch(classpathSorted, nestedJarFolder, "patch-chromium-swt");
 				SignedJars.stripIf(classpathSorted, fileName -> fileName.startsWith("org.eclipse.swt."));
 				vmArgs.add(

--- a/solstice/src/main/java/dev/equo/ide/EquoChromium.java
+++ b/solstice/src/main/java/dev/equo/ide/EquoChromium.java
@@ -24,9 +24,6 @@ import java.util.List;
  * plugins.
  */
 public class EquoChromium extends Catalog.PureMaven {
-
-	private boolean enabled = false;
-
 	EquoChromium() {
 		super(
 				"equoChromium",
@@ -42,23 +39,11 @@ public class EquoChromium extends Catalog.PureMaven {
 	}
 
 	public boolean isEnabled(Collection<File> classpath) {
-		if (classpath.stream().anyMatch(file -> file.getName().startsWith("com.equo.chromium"))) {
-			this.enabled = true;
-			return true;
-		}
-		return false;
+		return classpath.stream().anyMatch(file -> file.getName().startsWith("com.equo.chromium"));
 	}
 
 	public boolean isEnabled(P2Model model) {
-		if (model.getPureMaven().stream()
-				.anyMatch(coord -> coord.startsWith("com.equo:com.equo.chromium:"))) {
-			this.enabled = true;
-			return true;
-		}
-		return false;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
+		return model.getPureMaven().stream()
+				.anyMatch(coord -> coord.startsWith("com.equo:com.equo.chromium:"));
 	}
 }

--- a/solstice/src/main/java/dev/equo/ide/EquoChromium.java
+++ b/solstice/src/main/java/dev/equo/ide/EquoChromium.java
@@ -24,6 +24,9 @@ import java.util.List;
  * plugins.
  */
 public class EquoChromium extends Catalog.PureMaven {
+	
+	private boolean enabled = false;
+	
 	EquoChromium() {
 		super(
 				"equoChromium",
@@ -39,11 +42,22 @@ public class EquoChromium extends Catalog.PureMaven {
 	}
 
 	public boolean isEnabled(Collection<File> classpath) {
-		return classpath.stream().anyMatch(file -> file.getName().startsWith("com.equo.chromium"));
+		if (classpath.stream().anyMatch(file -> file.getName().startsWith("com.equo.chromium"))) {
+			this.enabled = true;
+			return true;
+		}
+		return false;
 	}
 
 	public boolean isEnabled(P2Model model) {
-		return model.getPureMaven().stream()
-				.anyMatch(coord -> coord.startsWith("com.equo:com.equo.chromium:"));
+		if (model.getPureMaven().stream().anyMatch(coord -> coord.startsWith("com.equo:com.equo.chromium:"))) {
+			this.enabled = true;
+			return true;
+		}
+		return false;
+	}
+
+	public boolean isEnabled() {
+		return this.enabled;
 	}
 }

--- a/solstice/src/main/java/dev/equo/ide/EquoChromium.java
+++ b/solstice/src/main/java/dev/equo/ide/EquoChromium.java
@@ -24,9 +24,9 @@ import java.util.List;
  * plugins.
  */
 public class EquoChromium extends Catalog.PureMaven {
-	
+
 	private boolean enabled = false;
-	
+
 	EquoChromium() {
 		super(
 				"equoChromium",
@@ -50,7 +50,8 @@ public class EquoChromium extends Catalog.PureMaven {
 	}
 
 	public boolean isEnabled(P2Model model) {
-		if (model.getPureMaven().stream().anyMatch(coord -> coord.startsWith("com.equo:com.equo.chromium:"))) {
+		if (model.getPureMaven().stream()
+				.anyMatch(coord -> coord.startsWith("com.equo:com.equo.chromium:"))) {
 			this.enabled = true;
 			return true;
 		}

--- a/solstice/src/main/java/dev/equo/ide/Launcher.java
+++ b/solstice/src/main/java/dev/equo/ide/Launcher.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -86,6 +87,12 @@ public class Launcher {
 		if (cwd != null) {
 			builder.directory(cwd);
 		}
+		
+		if (Catalog.EQUO_CHROMIUM.isEnabled()) {
+			Map<String, String> environment = builder.environment();
+			environment.put("GDK_BACKEND", "x11");	
+		}
+		
 		var process = builder.start();
 		var outPumper = new StreamPumper(process, process.getInputStream(), System.out);
 		var errPumper = new StreamPumper(process, process.getErrorStream(), System.err);

--- a/solstice/src/main/java/dev/equo/ide/Launcher.java
+++ b/solstice/src/main/java/dev/equo/ide/Launcher.java
@@ -83,14 +83,19 @@ public class Launcher {
 	public static int launchAndInheritIO(
 			File cwd, List<String> args, @Nullable Consumer<Process> monitorProcess)
 			throws IOException, InterruptedException {
+		return launchAndInheritIO(cwd, args, Map.of(), monitorProcess);
+	}
+
+	public static int launchAndInheritIO(
+			File cwd,
+			List<String> args,
+			Map<String, String> env,
+			@Nullable Consumer<Process> monitorProcess)
+			throws IOException, InterruptedException {
 		var builder = new ProcessBuilder(args);
+		builder.environment().putAll(env);
 		if (cwd != null) {
 			builder.directory(cwd);
-		}
-
-		if (Catalog.EQUO_CHROMIUM.isEnabled()) {
-			Map<String, String> environment = builder.environment();
-			environment.put("GDK_BACKEND", "x11");
 		}
 
 		var process = builder.start();

--- a/solstice/src/main/java/dev/equo/ide/Launcher.java
+++ b/solstice/src/main/java/dev/equo/ide/Launcher.java
@@ -87,12 +87,12 @@ public class Launcher {
 		if (cwd != null) {
 			builder.directory(cwd);
 		}
-		
+
 		if (Catalog.EQUO_CHROMIUM.isEnabled()) {
 			Map<String, String> environment = builder.environment();
-			environment.put("GDK_BACKEND", "x11");	
+			environment.put("GDK_BACKEND", "x11");
 		}
-		
+
 		var process = builder.start();
 		var outPumper = new StreamPumper(process, process.getInputStream(), System.out);
 		var errPumper = new StreamPumper(process, process.getErrorStream(), System.err);

--- a/solstice/src/main/java/dev/equo/ide/ScriptExec.java
+++ b/solstice/src/main/java/dev/equo/ide/ScriptExec.java
@@ -19,6 +19,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -38,6 +39,7 @@ class ScriptExec {
 
 	private final String script;
 	private Optional<File> directory = Optional.empty();
+	private Map<String, String> env = Map.of();
 
 	private ScriptExec(String script) {
 		this.script = Objects.requireNonNull(script);
@@ -46,6 +48,12 @@ class ScriptExec {
 	/** Sets the directory that the script will be run in. */
 	public ScriptExec directory(File directory) {
 		this.directory = Optional.of(directory);
+		return this;
+	}
+
+	/** Sets the directory that the script will be run in. */
+	public ScriptExec environment(Map<String, String> env) {
+		this.env = env;
 		return this;
 	}
 
@@ -70,7 +78,8 @@ class ScriptExec {
 		List<String> fullArgs = getPlatformCmds(scriptFile, isSeparate);
 
 		// set the cmds
-		int exitValue = Launcher.launchAndInheritIO(directory.orElse(null), fullArgs, monitorProcess);
+		int exitValue =
+				Launcher.launchAndInheritIO(directory.orElse(null), fullArgs, env, monitorProcess);
 		if (mavenWorkarounds()
 				&& ((OS.getNative().isLinux() && exitValue == 137)
 						|| (OS.getNative().isWindows() && exitValue == 1))) {


### PR DESCRIPTION
Without env-var:
![image](https://github.com/equodev/equo-ide/assets/64040737/44ba908b-8ce1-4380-a063-f2fc7981624c)

With env-var:
![image](https://github.com/equodev/equo-ide/assets/64040737/3f062e4c-3420-4773-86f6-ab32391fea99)

I'm not sure if this is the best way to determine if the equoChromium browser is enabled or not. What do you think of this solution?