### PR TITLE
Update Equo Chromium `106.0.9` -> `106.0.10`

### DIFF
--- a/solstice/src/main/java/dev/equo/ide/EquoChromium.java
+++ b/solstice/src/main/java/dev/equo/ide/EquoChromium.java
@@ -27,7 +27,7 @@ public class EquoChromium extends Catalog.PureMaven {
 	EquoChromium() {
 		super(
 				"equoChromium",
-				jre11("106.0.9"),
+				jre11("106.0.10"),
 				List.of(
 						"com.equo:com.equo.chromium:" + V,
 						"com.equo:com.equo.chromium.cef." + SwtPlatform.getRunning() + ":" + V),


### PR DESCRIPTION
This new version should solve the problem commented here: (https://github.com/equodev/equo-ide-chatgpt/issues/5)

"...hen suddenly a new Chrome tab opens (system Chrome, not Equo Chromium) and it opens to a random URL in the style of
file:///C:/Users/USERNAME/AppData/Local/Temp/chromium-506111696/tempfile7709515184394962614.html"