### PR TITLE
Fix third party login and urls with spaces

### DIFF
--- a/plugin-gradle/CHANGELOG.md
+++ b/plugin-gradle/CHANGELOG.md
@@ -4,9 +4,12 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
 ### Changed
-- Bump `equoChromium` default version `106.0.10` -> `106.0.12`.
+- Bump `equoChromium` default version `106.0.10` -> `106.0.13`.
 ### Fixed
-- Eclipse Welcome page is blank after restart with Equo Chromium.
+- Eclipse Welcome page is blank after restart with Equo Chromium. ([#157](https://github.com/equodev/equo-ide/pull/157))
+- Third party login in Equo Chromium Browser. ([#160](https://github.com/equodev/equo-ide/pull/160))
+- Manifest urls and osgi properties with spaces. ([#160](https://github.com/equodev/equo-ide/pull/160))
+- Failed to download p2repo when URL includes name and password. ([#160](https://github.com/equodev/equo-ide/pull/160))
 
 ## [1.7.1] - 2023-07-07
 ### Changed

--- a/plugin-maven/CHANGELOG.md
+++ b/plugin-maven/CHANGELOG.md
@@ -4,9 +4,12 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
 ### Changed
-- Bump `equoChromium` default version `106.0.10` -> `106.0.12`.
+- Bump `equoChromium` default version `106.0.10` -> `106.0.13`.
 ### Fixed
-- Eclipse Welcome page is blank after restart with Equo Chromium.
+- Eclipse Welcome page is blank after restart with Equo Chromium. ([#157](https://github.com/equodev/equo-ide/pull/157))
+- Third party login in Equo Chromium Browser. ([#160](https://github.com/equodev/equo-ide/pull/160))
+- Manifest urls and osgi properties with spaces. ([#160](https://github.com/equodev/equo-ide/pull/160))
+- Failed to download p2repo when URL includes name and password. ([#160](https://github.com/equodev/equo-ide/pull/160))
 
 ## [1.5.1] - 2023-07-07
 ### Changed

--- a/solstice/CHANGELOG.md
+++ b/solstice/CHANGELOG.md
@@ -4,9 +4,12 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
 ### Changed
-- Bump `equoChromium` default version `106.0.10` -> `106.0.12`.
+- Bump `equoChromium` default version `106.0.10` -> `106.0.13`.
 ### Fixed
-- Eclipse Welcome page is blank after restart with Equo Chromium.
+- Eclipse Welcome page is blank after restart with Equo Chromium. ([#157](https://github.com/equodev/equo-ide/pull/157))
+- Third party login in Equo Chromium Browser. ([#160](https://github.com/equodev/equo-ide/pull/160))
+- Manifest urls and osgi properties with spaces. ([#160](https://github.com/equodev/equo-ide/pull/160))
+- Failed to download p2repo when URL includes name and password. ([#160](https://github.com/equodev/equo-ide/pull/160))
 
 ## [1.7.1] - 2023-07-07
 ### Changed

--- a/solstice/src/main/java/dev/equo/ide/BuildPluginIdeMain.java
+++ b/solstice/src/main/java/dev/equo/ide/BuildPluginIdeMain.java
@@ -39,6 +39,7 @@ import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
 
+import com.diffplug.common.swt.os.OS;
 /**
  * A main method for launching an IDE using Solstice. It has a verbose command line interface which
  * is optimized for integration with the EquoIDE Gradle and Maven build plugins, but it can be used
@@ -100,8 +101,16 @@ public class BuildPluginIdeMain {
 			var vmArgs = new ArrayList<String>();
 			var environmentVars = new LinkedHashMap<String, String>();
 			if (Catalog.EQUO_CHROMIUM.isEnabled(classpath)) {
+				List<String> chromiumArgs = new ArrayList<String>();
+				
 				// This property is used to fix the error in the setUrl method.
-				vmArgs.add("-Dchromium.args=--disable-site-isolation-trials");
+				chromiumArgs.add("--disable-site-isolation-trials");
+				
+				// This property is used to fix the error when logging in with a third party.
+				chromiumArgs.add("--user-agent=" + EquoChromium.getUserAgent());
+				
+				vmArgs.add("-Dchromium.args=" + String.join(";", chromiumArgs));
+			
 				// This property improve loading time of setText for large resources.
 				vmArgs.add("-Dchromium.setTextAsUrl=file:");
 				// Fix graphics on linux

--- a/solstice/src/main/java/dev/equo/ide/BuildPluginIdeMain.java
+++ b/solstice/src/main/java/dev/equo/ide/BuildPluginIdeMain.java
@@ -39,7 +39,6 @@ import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
 
-import com.diffplug.common.swt.os.OS;
 /**
  * A main method for launching an IDE using Solstice. It has a verbose command line interface which
  * is optimized for integration with the EquoIDE Gradle and Maven build plugins, but it can be used
@@ -102,15 +101,15 @@ public class BuildPluginIdeMain {
 			var environmentVars = new LinkedHashMap<String, String>();
 			if (Catalog.EQUO_CHROMIUM.isEnabled(classpath)) {
 				List<String> chromiumArgs = new ArrayList<String>();
-				
+
 				// This property is used to fix the error in the setUrl method.
 				chromiumArgs.add("--disable-site-isolation-trials");
-				
+
 				// This property is used to fix the error when logging in with a third party.
 				chromiumArgs.add("--user-agent=" + EquoChromium.getUserAgent());
-				
+
 				vmArgs.add("-Dchromium.args=" + String.join(";", chromiumArgs));
-			
+
 				// This property improve loading time of setText for large resources.
 				vmArgs.add("-Dchromium.setTextAsUrl=file:");
 				// Fix graphics on linux

--- a/solstice/src/main/java/dev/equo/ide/EquoChromium.java
+++ b/solstice/src/main/java/dev/equo/ide/EquoChromium.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package dev.equo.ide;
 
+import com.diffplug.common.swt.os.OS;
 import com.diffplug.common.swt.os.SwtPlatform;
 import dev.equo.solstice.p2.P2Model;
 import java.io.File;
@@ -24,10 +25,13 @@ import java.util.List;
  * plugins.
  */
 public class EquoChromium extends Catalog.PureMaven {
+	
+	private static final String EQUO_CHROMIUM_VERSION = "106.0.12";
+	
 	EquoChromium() {
 		super(
 				"equoChromium",
-				jre11("106.0.12"),
+				jre11(EQUO_CHROMIUM_VERSION),
 				List.of(
 						"com.equo:com.equo.chromium:" + V,
 						"com.equo:com.equo.chromium.cef." + SwtPlatform.getRunning() + ":" + V),
@@ -45,5 +49,24 @@ public class EquoChromium extends Catalog.PureMaven {
 	public boolean isEnabled(P2Model model) {
 		return model.getPureMaven().stream()
 				.anyMatch(coord -> coord.startsWith("com.equo:com.equo.chromium:"));
+	}
+	
+	public static String getUserAgent() {
+		String chromiumMajor = EQUO_CHROMIUM_VERSION.split("\\.")[0];
+		if (OS.getRunning().isLinux()) {
+			return "Mozilla/5.0 (X11\\; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/" + chromiumMajor
+					+ ".0.0.0 Safari/537.36";
+		} else if (OS.getRunning().isWindows()) {
+			return "Mozilla/5.0 (Windows NT 10.0\\; Win64\\; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/"
+					+ chromiumMajor + ".0.0.0 Safari/537.36";
+		} else {
+			String osVersion = "10_0_0";
+			String osVersionProperty = System.getProperty("os.version");
+			if (osVersionProperty != null) {
+				osVersion = osVersionProperty.replace(".", "_");
+			}
+			return "Mozilla/5.0 (Macintosh\\; Intel Mac OS X " + osVersion
+					+ ") AppleWebKit/537.36 (KHTML, like Gecko) Chrome/" + chromiumMajor + ".0.0.0 Safari/537.36";
+		}
 	}
 }

--- a/solstice/src/main/java/dev/equo/ide/EquoChromium.java
+++ b/solstice/src/main/java/dev/equo/ide/EquoChromium.java
@@ -26,7 +26,7 @@ import java.util.List;
  */
 public class EquoChromium extends Catalog.PureMaven {
 	
-	private static final String EQUO_CHROMIUM_VERSION = "106.0.12";
+	private static final String EQUO_CHROMIUM_VERSION = "106.0.13";
 	
 	EquoChromium() {
 		super(

--- a/solstice/src/main/java/dev/equo/ide/EquoChromium.java
+++ b/solstice/src/main/java/dev/equo/ide/EquoChromium.java
@@ -25,9 +25,9 @@ import java.util.List;
  * plugins.
  */
 public class EquoChromium extends Catalog.PureMaven {
-	
+
 	private static final String EQUO_CHROMIUM_VERSION = "106.0.13";
-	
+
 	EquoChromium() {
 		super(
 				"equoChromium",
@@ -50,23 +50,28 @@ public class EquoChromium extends Catalog.PureMaven {
 		return model.getPureMaven().stream()
 				.anyMatch(coord -> coord.startsWith("com.equo:com.equo.chromium:"));
 	}
-	
+
 	public static String getUserAgent() {
 		String chromiumMajor = EQUO_CHROMIUM_VERSION.split("\\.")[0];
 		if (OS.getRunning().isLinux()) {
-			return "Mozilla/5.0 (X11\\; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/" + chromiumMajor
+			return "Mozilla/5.0 (X11\\; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/"
+					+ chromiumMajor
 					+ ".0.0.0 Safari/537.36";
 		} else if (OS.getRunning().isWindows()) {
 			return "Mozilla/5.0 (Windows NT 10.0\\; Win64\\; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/"
-					+ chromiumMajor + ".0.0.0 Safari/537.36";
+					+ chromiumMajor
+					+ ".0.0.0 Safari/537.36";
 		} else {
 			String osVersion = "10_0_0";
 			String osVersionProperty = System.getProperty("os.version");
 			if (osVersionProperty != null) {
 				osVersion = osVersionProperty.replace(".", "_");
 			}
-			return "Mozilla/5.0 (Macintosh\\; Intel Mac OS X " + osVersion
-					+ ") AppleWebKit/537.36 (KHTML, like Gecko) Chrome/" + chromiumMajor + ".0.0.0 Safari/537.36";
+			return "Mozilla/5.0 (Macintosh\\; Intel Mac OS X "
+					+ osVersion
+					+ ") AppleWebKit/537.36 (KHTML, like Gecko) Chrome/"
+					+ chromiumMajor
+					+ ".0.0.0 Safari/537.36";
 		}
 	}
 }

--- a/solstice/src/main/java/dev/equo/solstice/BundleContextShim.java
+++ b/solstice/src/main/java/dev/equo/solstice/BundleContextShim.java
@@ -17,6 +17,8 @@ import com.diffplug.common.swt.os.SwtPlatform;
 import dev.equo.solstice.platform.Handler;
 import java.io.File;
 import java.io.InputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -87,7 +89,7 @@ public class BundleContextShim extends ServiceRegistry {
 				(key, value) -> {
 					if (ShimIdeBootstrapServices.locationKeys().contains(key)) {
 						if (!value.startsWith("file:")) {
-							value = new File(value).toURI().toString();
+							value = URLDecoder.decode(new File(value).toURI().toString(), StandardCharsets.UTF_8);
 						}
 						if (!value.endsWith("/")) {
 							value = value + "/";

--- a/solstice/src/main/java/dev/equo/solstice/ShimIdeBootstrapServices.java
+++ b/solstice/src/main/java/dev/equo/solstice/ShimIdeBootstrapServices.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Hashtable;
@@ -100,7 +102,7 @@ public class ShimIdeBootstrapServices {
 				DebugOptions.class, context.container.getConfiguration().getDebugOptions(), null);
 		var instanceArea = context.getProperty(EquinoxLocations.PROP_INSTANCE_AREA);
 		if (instanceArea != null) {
-			var instanceDir = Unchecked.get(() -> new File(new URI(instanceArea)));
+			var instanceDir = Unchecked.get(() -> new File(URLEncoder.encode(instanceArea, StandardCharsets.UTF_8)));
 			context.registerService(
 					URLConverter.class,
 					new JarUrlResolver(new File(instanceDir, "JarUrlResolver")),

--- a/solstice/src/main/java/dev/equo/solstice/ShimIdeBootstrapServices.java
+++ b/solstice/src/main/java/dev/equo/solstice/ShimIdeBootstrapServices.java
@@ -16,7 +16,6 @@ package dev.equo.solstice;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -102,7 +101,8 @@ public class ShimIdeBootstrapServices {
 				DebugOptions.class, context.container.getConfiguration().getDebugOptions(), null);
 		var instanceArea = context.getProperty(EquinoxLocations.PROP_INSTANCE_AREA);
 		if (instanceArea != null) {
-			var instanceDir = Unchecked.get(() -> new File(URLEncoder.encode(instanceArea, StandardCharsets.UTF_8)));
+			var instanceDir =
+					Unchecked.get(() -> new File(URLEncoder.encode(instanceArea, StandardCharsets.UTF_8)));
 			context.registerService(
 					URLConverter.class,
 					new JarUrlResolver(new File(instanceDir, "JarUrlResolver")),

--- a/solstice/src/main/java/dev/equo/solstice/SolsticeManifest.java
+++ b/solstice/src/main/java/dev/equo/solstice/SolsticeManifest.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -75,7 +77,7 @@ public class SolsticeManifest {
 
 	SolsticeManifest(URL manifestURL, int classpathOrder) {
 		this.classpathOrder = classpathOrder;
-		var externalForm = manifestURL.toExternalForm();
+		var externalForm = URLDecoder.decode(manifestURL.toExternalForm(), StandardCharsets.UTF_8);
 		if (!externalForm.endsWith(SLASH_MANIFEST_PATH)) {
 			throw new IllegalArgumentException(
 					"Expected manifest to end with " + SLASH_MANIFEST_PATH + " but was " + externalForm);

--- a/solstice/src/main/java/dev/equo/solstice/p2/P2Client.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/P2Client.java
@@ -27,18 +27,15 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-
 import javax.xml.parsers.DocumentBuilderFactory;
-
-import org.tukaani.xz.XZInputStream;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import okhttp3.Cache;
 import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import org.tukaani.xz.XZInputStream;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /** Performs network requests and parsing against a P2 repository, aided by caching. */
 public class P2Client implements AutoCloseable {
@@ -134,7 +131,7 @@ public class P2Client implements AutoCloseable {
 		}
 		return true;
 	}
-	
+
 	private static Request buildRequest(String url) {
 		// Check if url contains basic authentication, e.g. http://username:password@example.com/dir
 		String[] info = null;

--- a/solstice/src/main/java/dev/equo/solstice/p2/P2Client.java
+++ b/solstice/src/main/java/dev/equo/solstice/p2/P2Client.java
@@ -16,6 +16,7 @@ package dev.equo.solstice.p2;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
@@ -26,14 +27,18 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+
 import javax.xml.parsers.DocumentBuilderFactory;
-import okhttp3.Cache;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
+
 import org.tukaani.xz.XZInputStream;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import okhttp3.Cache;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
 
 /** Performs network requests and parsing against a P2 repository, aided by caching. */
 public class P2Client implements AutoCloseable {
@@ -129,6 +134,25 @@ public class P2Client implements AutoCloseable {
 		}
 		return true;
 	}
+	
+	private static Request buildRequest(String url) {
+		// Check if url contains basic authentication, e.g. http://username:password@example.com/dir
+		String[] info = null;
+		try {
+			URL netUrl = new URL(url);
+			String userInfo = netUrl.getUserInfo();
+			if (userInfo != null) {
+				info = userInfo.split(":");
+			}
+		} catch (Exception ignored) {
+		}
+		Request.Builder builder = new Request.Builder().url(url);
+		if (info != null && info.length == 2) {
+			String credential = Credentials.basic(info[0], info[1]);
+			builder.addHeader("Authorization", credential);
+		}
+		return builder.build();
+	}
 
 	private byte[] getBytes(String url) throws IOException, NotFoundException {
 		if (cachingPolicy.tryOfflineFirst()) {
@@ -141,7 +165,7 @@ public class P2Client implements AutoCloseable {
 			}
 		}
 		if (cachingPolicy.networkAllowed()) {
-			var request = new Request.Builder().url(url).build();
+			var request = buildRequest(url);
 			try (var response = metadataClient.newCall(request).execute()) {
 				if (response.code() == 404) {
 					if (cachingPolicy.cacheAllowed()) {


### PR DESCRIPTION
- This Pull Request fixes the issue of not being able to log in with third-party applications (for example, ChatGPT with Google).

- I discovered the bug with URLs while running EquoIDE with a username that contained a space.