### PR TITLE
Stop prematurely decoding `jarUrl` in `SolsticeManifest`.

### DIFF
--- a/solstice/CHANGELOG.md
+++ b/solstice/CHANGELOG.md
@@ -3,6 +3,8 @@
 We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## [Unreleased]
+### Fixed
+- Stop prematurely decoding `jarUrl` in `SolsticeManifest` to fix nested jars that have `+` in their name. ([#166](https://github.com/equodev/equo-ide/pull/166) fixes [diffplug/spotless#1860](https://github.com/diffplug/spotless/issues/1860#issuecomment-1826113332)) 
 
 ## [1.7.3] - 2023-08-29
 ### Fixed

--- a/solstice/src/main/java/dev/equo/solstice/SolsticeManifest.java
+++ b/solstice/src/main/java/dev/equo/solstice/SolsticeManifest.java
@@ -18,8 +18,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -77,7 +75,7 @@ public class SolsticeManifest {
 
 	SolsticeManifest(URL manifestURL, int classpathOrder) {
 		this.classpathOrder = classpathOrder;
-		var externalForm = URLDecoder.decode(manifestURL.toExternalForm(), StandardCharsets.UTF_8);
+		var externalForm = manifestURL.toExternalForm();
 		if (!externalForm.endsWith(SLASH_MANIFEST_PATH)) {
 			throw new IllegalArgumentException(
 					"Expected manifest to end with " + SLASH_MANIFEST_PATH + " but was " + externalForm);


### PR DESCRIPTION
This undoes a small part of

- #160 

but it fixes

- https://github.com/diffplug/spotless/issues/1860#issuecomment-1826113332

If this decoding needs to happen, it should happen at the use-site, not at `jarUrl`, and it seems like that decoding is happening correctly at the username site as-is.

@agustinschilling just FYI, this fixes a known problem, apologies if it creates others too, but I don't think it will.